### PR TITLE
Simple eRPA code checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <img src="https://render.githubusercontent.com/render/math?math=p^{\dagger}q">
-------------------------------------------------------------------------------
+
 pdaggeq is a fermionic computer algebra package for bringing strings of creation / annihilation operators to normal
 order with respect to a true vacuum or Fermi vacuum. The code also evalutes projections used in coupled cluster theory
 and can be used to generate full working coupled cluster codes. In the examples section we provide worked examples that

--- a/examples/extended_rpa.py
+++ b/examples/extended_rpa.py
@@ -4,6 +4,9 @@ Evaluate the double commutator associated with extended RPA equations
 from typing import List
 import pdaggerq
 
+from pdaggerq.parser import vacuum_normal_ordered_strings_to_tensor_terms
+from pdaggerq.algebra import TensorTerm, Delta, Index, BaseTerm
+
 
 def pq_commutator(ahat, left_op_string: List[str], right_op_string: List[str],
                   scaling_coeff=1.0):
@@ -49,6 +52,33 @@ def pq_double_commutator(ahat, left_op_string: List[str],
     return ahat
 
 
+def erpa_terms_to_einsum(tensor_terms: List[TensorTerm],
+                         constant_terms=['r', 's', 'p', 'q'],
+                         contract_d2_with='k2'):
+    """
+    Generate terms einsum contractions for the ERPA matrix
+
+    This is the simplest contraction generation and should only be used to
+    check if other simplified codes are correct.  The deltafunctions are not
+    removed and thus the user must specify an identity matrix called kd.  To
+
+    get the erpa matrix reshape the 4-tensor with labels (pqrs) into a matrix
+    with row indices rs and column indices pq.
+    """
+    k2_idx = [Index('i', 'all'), Index('j', 'all'), Index('k', 'all'), Index('l', 'all')]
+    for tt in tensor_terms:
+        # add the hamiltonian to contract with
+        tt.base_terms += (BaseTerm(indices=tuple(k2_idx), name=contract_d2_with),)
+
+        print("# ", tt)
+        print(tt.einsum_string(update_val='erpa_val',
+                               occupied=['i', 'j', 'k', 'l', 'r', 's', 'p', 'q'],
+                               virtual=[],
+                               output_variables=constant_terms,
+                               optimize=False))
+        print()
+
+
 def main():
     # need cumulant decomposition on 3-RDM terms
     # to simplify to a 2-RDM + 1-RDM expression
@@ -88,8 +118,16 @@ def main():
     ahat = pdaggerq.pq_helper('true')
 
     ahat = pq_double_commutator(ahat, ['r*', 's'], ['i*','j*','k','l'],  ['p*', 'q'])
-    ahat.print()
+    # print(ahat.strings())
+
+
+    rpa_tensor_terms = vacuum_normal_ordered_strings_to_tensor_terms(ahat.strings())
+
     ahat.clear()
+    print(rpa_tensor_terms)
+
+    erpa_terms_to_einsum(tensor_terms=rpa_tensor_terms)
+
 
 
 if __name__ == "__main__":

--- a/pdaggerq/algebra.py
+++ b/pdaggerq/algebra.py
@@ -124,7 +124,8 @@ class TensorTerm:
                       occupied=['i', 'j', 'k', 'l', 'm', 'n'],
                       virtual=['a', 'b', 'c', 'd', 'e', 'f'],
                       occ_char=None,
-                      virt_char=None,):
+                      virt_char=None,
+                      optimize=True):
         einsum_out_strings = ""
         einsum_tensors = []
         tensor_out_idx = []
@@ -169,7 +170,7 @@ class TensorTerm:
 
         teinsum_string = "+= {} * einsum(\'".format(self.coefficient)
 
-        if len(einsum_strings) > 2:
+        if len(einsum_strings) > 2 and optimize:
             sorbs = 8
             nocc = 4
             nvirt = sorbs - nocc
@@ -312,5 +313,9 @@ class TwoBody(BaseTerm):
 
 
 class Delta(BaseTerm):
+
+    def __init__(self, *, indices=Tuple[Index,...], name='kd'):
+        super().__init__(indices=indices, name=name)
+
     def __repr__(self):
         return "d({},{})".format(self.indices[0], self.indices[1])


### PR DESCRIPTION
Unsimplified double commutator contractions to check more complex non
spinorbital codes.

The e-rpa example now generates a very simple code for erpa "matrix" elements.  It assumes the Hamiltonian is represented as a 2-body operator (like K2) in OpenFermion format <12|21>.  The d2 is the 2-RDM in the same <1221> format.  Since I didn't add code to simplify the einsum contraction by resolving the delta functions each kronecker delta must be contracted over.   Just initialize an identity matrix called kd.  

More sophisticated code can be added to the algebra object for generating einsum codes with general indices and resolving delta functions.  As you can see I used the cc-einsum code and just set all indices to occupied as a hack to use the existing infrastructure.  