### PR TITLE
Less memory

### DIFF
--- a/pdaggerq/pq.cc
+++ b/pdaggerq/pq.cc
@@ -796,8 +796,8 @@ void pq::cleanup(std::vector<std::shared_ptr<pq> > &ordered) {
     consolidate_permutations_plus_two_swaps(ordered,vir_labels,vir_labels);
     consolidate_permutations_plus_two_swaps(ordered,occ_labels,vir_labels);
 
+    // these don't seem to be necessary for test cases up to ccsdtq
 /*
-    // these don't seem to be necessary for test cases up to ccsdt
     consolidate_permutations_plus_three_swaps(ordered,occ_labels,occ_labels,occ_labels);
     consolidate_permutations_plus_three_swaps(ordered,occ_labels,occ_labels,vir_labels);
     consolidate_permutations_plus_three_swaps(ordered,occ_labels,vir_labels,vir_labels);
@@ -808,6 +808,40 @@ void pq::cleanup(std::vector<std::shared_ptr<pq> > &ordered) {
     consolidate_permutations_plus_four_swaps(ordered,occ_labels,occ_labels,vir_labels,vir_labels);
     consolidate_permutations_plus_four_swaps(ordered,occ_labels,vir_labels,vir_labels,vir_labels);
     consolidate_permutations_plus_four_swaps(ordered,vir_labels,vir_labels,vir_labels,vir_labels);
+
+    consolidate_permutations_plus_five_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels);
+    consolidate_permutations_plus_five_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels);
+    consolidate_permutations_plus_five_swaps(ordered,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_five_swaps(ordered,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_five_swaps(ordered,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_five_swaps(ordered,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+
+    consolidate_permutations_plus_six_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels);
+    consolidate_permutations_plus_six_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels);
+    consolidate_permutations_plus_six_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_six_swaps(ordered,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_six_swaps(ordered,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_six_swaps(ordered,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_six_swaps(ordered,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+
+    consolidate_permutations_plus_seven_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels);
+    consolidate_permutations_plus_seven_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels);
+    consolidate_permutations_plus_seven_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_seven_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_seven_swaps(ordered,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_seven_swaps(ordered,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_seven_swaps(ordered,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_seven_swaps(ordered,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+
+    consolidate_permutations_plus_eight_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels);
+    consolidate_permutations_plus_eight_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels);
+    consolidate_permutations_plus_eight_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_eight_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_eight_swaps(ordered,occ_labels,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_eight_swaps(ordered,occ_labels,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_eight_swaps(ordered,occ_labels,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_eight_swaps(ordered,occ_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
+    consolidate_permutations_plus_eight_swaps(ordered,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels,vir_labels);
 */
 
     // probably only relevant for vacuum = fermi
@@ -854,16 +888,22 @@ void pq::consolidate_permutations_non_summed(
         // ok, what labels do we have? 
         for (size_t j = 0; j < labels.size(); j++) {
             int found = ordered[i]->index_in_anywhere(labels[j]);
-            // make sure label isn't already in a permutation operator
-            bool already_found = false;
+            // this is buggy when existing permutation labels belong to 
+            // the same space as the labels we're permuting ... so skip those for now.
+            bool same_space = false;
+            bool is_occ1 = is_occ(labels[j]);
             for (size_t k = 0; k < ordered[i]->data->permutations.size(); k++) {
-                if ( ordered[i]->data->permutations[k] == labels[j] ) {
-                    already_found = true;
+                bool is_occ2 = is_occ(ordered[i]->data->permutations[k]);
+                if ( is_occ1 && is_occ2 ) {
+                    same_space = true;
+                    break;
+                }else if ( !is_occ1 && !is_occ2 ) {
+                    same_space = true;
                     break;
                 }
             }
 
-            if ( !already_found ) {
+            if ( !same_space ) {
                 find_idx.push_back(found);
             }else{
                 find_idx.push_back(0);
@@ -952,6 +992,689 @@ void pq::consolidate_permutations_non_summed(
     }
 }
 
+
+// consolidate terms that differ by eight summed labels plus permutations
+void pq::consolidate_permutations_plus_eight_swaps(
+    std::vector<std::shared_ptr<pq> > &ordered,
+    std::vector<std::string> labels_1,
+    std::vector<std::string> labels_2, 
+    std::vector<std::string> labels_3,
+    std::vector<std::string> labels_4,
+    std::vector<std::string> labels_5,
+    std::vector<std::string> labels_6,
+    std::vector<std::string> labels_7,
+    std::vector<std::string> labels_8) {
+
+    for (size_t i = 0; i < ordered.size(); i++) {
+
+        if ( ordered[i]->skip ) continue;
+
+        std::vector<int> find_1;
+        std::vector<int> find_2;
+        std::vector<int> find_3;
+        std::vector<int> find_4;
+        std::vector<int> find_5;
+        std::vector<int> find_6;
+        std::vector<int> find_7;
+        std::vector<int> find_8;
+
+        // ok, what labels do we have? list 1
+        for (size_t j = 0; j < labels_1.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_1[j]);
+            find_1.push_back(found);
+        }
+
+        // ok, what labels do we have? list 2
+        for (size_t j = 0; j < labels_2.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_2[j]);
+            find_2.push_back(found);
+        }
+
+        // ok, what labels do we have? list 3
+        for (size_t j = 0; j < labels_3.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_3[j]);
+            find_3.push_back(found);
+        }
+
+        // ok, what labels do we have? list 4
+        for (size_t j = 0; j < labels_4.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_4[j]);
+            find_4.push_back(found);
+        }
+
+        // ok, what labels do we have? list 5
+        for (size_t j = 0; j < labels_5.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_5[j]);
+            find_5.push_back(found);
+        }
+
+        // ok, what labels do we have? list 6
+        for (size_t j = 0; j < labels_6.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_6[j]);
+            find_6.push_back(found);
+        }
+
+        // ok, what labels do we have? list 7
+        for (size_t j = 0; j < labels_7.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_7[j]);
+            find_7.push_back(found);
+        }
+
+        // ok, what labels do we have? list 8
+        for (size_t j = 0; j < labels_8.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_8[j]);
+            find_8.push_back(found);
+        }
+
+        for (size_t j = i+1; j < ordered.size(); j++) {
+
+            if ( ordered[j]->skip ) continue;
+
+            int n_permute;
+            bool strings_same = compare_strings(ordered[i],ordered[j],n_permute);
+
+            // try swapping non-summed labels 1
+            for (size_t id1 = 0; id1 < labels_1.size(); id1++) {
+                if ( find_1[id1] != 2 ) continue;
+                for (size_t id2 = id1 + 1; id2 < labels_1.size(); id2++) {
+                    if ( find_1[id2] != 2 ) continue;
+
+                    // try swapping non-summed labels 2
+                    for (size_t id3 = 0; id3 < labels_2.size(); id3++) {
+                        if ( find_2[id3] != 2 ) continue;
+                        for (size_t id4 = id3 + 1; id4 < labels_2.size(); id4++) {
+                            if ( find_2[id4] != 2 ) continue;
+
+                            // try swapping non-summed labels 3
+                            for (size_t id5 = 0; id5 < labels_3.size(); id5++) {
+                                if ( find_3[id5] != 2 ) continue;
+                                for (size_t id6 = id5 + 1; id6 < labels_3.size(); id6++) {
+                                    if ( find_3[id6] != 2 ) continue;
+
+                                    // try swapping non-summed labels 4
+                                    for (size_t id7 = 0; id7 < labels_4.size(); id7++) {
+                                        if ( find_4[id7] != 2 ) continue;
+                                        for (size_t id8 = id7 + 1; id8 < labels_4.size(); id8++) {
+                                            if ( find_4[id8] != 2 ) continue;
+
+                                            // try swapping non-summed labels 5
+                                            for (size_t id9 = 0; id9 < labels_5.size(); id9++) {
+                                                if ( find_5[id9] != 2 ) continue;
+                                                for (size_t id10 = id9 + 1; id10 < labels_5.size(); id10++) {
+                                                    if ( find_5[id10] != 2 ) continue;
+
+                                                    // try swapping non-summed labels 6
+                                                    for (size_t id11 = 0; id11 < labels_6.size(); id11++) {
+                                                        if ( find_6[id11] != 2 ) continue;
+                                                        for (size_t id12 = id11 + 1; id12 < labels_6.size(); id12++) {
+                                                            if ( find_6[id12] != 2 ) continue;
+
+                                                            // try swapping non-summed labels 7
+                                                            for (size_t id13 = 0; id13 < labels_7.size(); id13++) {
+                                                                if ( find_7[id13] != 2 ) continue;
+                                                                for (size_t id14 = id13 + 1; id14 < labels_7.size(); id14++) {
+                                                                    if ( find_7[id14] != 2 ) continue;
+
+                                                                    // try swapping non-summed labels 8
+                                                                    for (size_t id15 = 0; id15 < labels_8.size(); id15++) {
+                                                                        if ( find_8[id15] != 2 ) continue;
+                                                                        for (size_t id16 = id15 + 1; id16 < labels_8.size(); id16++) {
+                                                                            if ( find_8[id16] != 2 ) continue;
+
+                                                                            std::shared_ptr<pq> newguy (new pq(vacuum));
+                                                                            newguy->copy((void*)(ordered[i].get()));
+                                                                            newguy->swap_two_labels(labels_1[id1],labels_1[id2]);
+                                                                            newguy->swap_two_labels(labels_2[id3],labels_2[id4]);
+                                                                            newguy->swap_two_labels(labels_3[id5],labels_3[id6]);
+                                                                            newguy->swap_two_labels(labels_4[id7],labels_4[id8]);
+                                                                            newguy->swap_two_labels(labels_5[id9],labels_5[id10]);
+                                                                            newguy->swap_two_labels(labels_6[id11],labels_6[id12]);
+                                                                            newguy->swap_two_labels(labels_7[id13],labels_7[id14]);
+                                                                            newguy->swap_two_labels(labels_8[id15],labels_8[id16]);
+                                                                            strings_same = compare_strings(ordered[j],newguy,n_permute);
+
+                                                                            if ( strings_same ) break;
+                                                                        }
+                                                                        if ( strings_same ) break;
+                                                                    }
+                                                                    if ( strings_same ) break;
+                                                                }
+                                                                if ( strings_same ) break;
+                                                            }
+                                                            if ( strings_same ) break;
+                                                        }
+                                                        if ( strings_same ) break;
+                                                    }
+                                                    if ( strings_same ) break;
+                                                }
+                                                if ( strings_same ) break;
+                                            }
+                                            if ( strings_same ) break;
+                                        }
+                                        if ( strings_same ) break;
+                                    }
+                                    if ( strings_same ) break;
+                                }
+                                if ( strings_same ) break;
+                            }
+                            if ( strings_same ) break;
+                        }
+                        if ( strings_same ) break;
+                    }
+                    if ( strings_same ) break;
+                }
+                if ( strings_same ) break;
+            }
+
+            if ( !strings_same ) continue;
+
+            double factor_i = ordered[i]->data->factor * ordered[i]->sign;
+            double factor_j = ordered[j]->data->factor * ordered[j]->sign;
+
+            double combined_factor = factor_i + factor_j * pow(-1.0,n_permute);
+
+            // if terms exactly cancel, do so
+            if ( fabs(combined_factor) < 1e-12 ) {
+                ordered[i]->skip = true;
+                ordered[j]->skip = true;
+                break;
+            }
+
+            // otherwise, combine terms
+            ordered[i]->data->factor = fabs(combined_factor);
+            if ( combined_factor > 0.0 ) {
+                ordered[i]->sign =  1;
+            }else {
+                ordered[i]->sign = -1;
+            }
+            ordered[j]->skip = true;
+
+        }
+    }
+}
+// consolidate terms that differ by seven summed labels plus permutations
+void pq::consolidate_permutations_plus_seven_swaps(
+    std::vector<std::shared_ptr<pq> > &ordered,
+    std::vector<std::string> labels_1,
+    std::vector<std::string> labels_2, 
+    std::vector<std::string> labels_3,
+    std::vector<std::string> labels_4,
+    std::vector<std::string> labels_5,
+    std::vector<std::string> labels_6,
+    std::vector<std::string> labels_7) {
+
+    for (size_t i = 0; i < ordered.size(); i++) {
+
+        if ( ordered[i]->skip ) continue;
+
+        std::vector<int> find_1;
+        std::vector<int> find_2;
+        std::vector<int> find_3;
+        std::vector<int> find_4;
+        std::vector<int> find_5;
+        std::vector<int> find_6;
+        std::vector<int> find_7;
+
+        // ok, what labels do we have? list 1
+        for (size_t j = 0; j < labels_1.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_1[j]);
+            find_1.push_back(found);
+        }
+
+        // ok, what labels do we have? list 2
+        for (size_t j = 0; j < labels_2.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_2[j]);
+            find_2.push_back(found);
+        }
+
+        // ok, what labels do we have? list 3
+        for (size_t j = 0; j < labels_3.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_3[j]);
+            find_3.push_back(found);
+        }
+
+        // ok, what labels do we have? list 4
+        for (size_t j = 0; j < labels_4.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_4[j]);
+            find_4.push_back(found);
+        }
+
+        // ok, what labels do we have? list 5
+        for (size_t j = 0; j < labels_5.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_5[j]);
+            find_5.push_back(found);
+        }
+
+        // ok, what labels do we have? list 6
+        for (size_t j = 0; j < labels_6.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_6[j]);
+            find_6.push_back(found);
+        }
+
+        // ok, what labels do we have? list 7
+        for (size_t j = 0; j < labels_7.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_7[j]);
+            find_7.push_back(found);
+        }
+
+        for (size_t j = i+1; j < ordered.size(); j++) {
+
+            if ( ordered[j]->skip ) continue;
+
+            int n_permute;
+            bool strings_same = compare_strings(ordered[i],ordered[j],n_permute);
+
+            // try swapping non-summed labels 1
+            for (size_t id1 = 0; id1 < labels_1.size(); id1++) {
+                if ( find_1[id1] != 2 ) continue;
+                for (size_t id2 = id1 + 1; id2 < labels_1.size(); id2++) {
+                    if ( find_1[id2] != 2 ) continue;
+
+                    // try swapping non-summed labels 2
+                    for (size_t id3 = 0; id3 < labels_2.size(); id3++) {
+                        if ( find_2[id3] != 2 ) continue;
+                        for (size_t id4 = id3 + 1; id4 < labels_2.size(); id4++) {
+                            if ( find_2[id4] != 2 ) continue;
+
+                            // try swapping non-summed labels 3
+                            for (size_t id5 = 0; id5 < labels_3.size(); id5++) {
+                                if ( find_3[id5] != 2 ) continue;
+                                for (size_t id6 = id5 + 1; id6 < labels_3.size(); id6++) {
+                                    if ( find_3[id6] != 2 ) continue;
+
+                                    // try swapping non-summed labels 4
+                                    for (size_t id7 = 0; id7 < labels_4.size(); id7++) {
+                                        if ( find_4[id7] != 2 ) continue;
+                                        for (size_t id8 = id7 + 1; id8 < labels_4.size(); id8++) {
+                                            if ( find_4[id8] != 2 ) continue;
+
+                                            // try swapping non-summed labels 5
+                                            for (size_t id9 = 0; id9 < labels_5.size(); id9++) {
+                                                if ( find_5[id9] != 2 ) continue;
+                                                for (size_t id10 = id9 + 1; id10 < labels_5.size(); id10++) {
+                                                    if ( find_5[id10] != 2 ) continue;
+
+                                                    // try swapping non-summed labels 6
+                                                    for (size_t id11 = 0; id11 < labels_6.size(); id11++) {
+                                                        if ( find_6[id11] != 2 ) continue;
+                                                        for (size_t id12 = id11 + 1; id12 < labels_6.size(); id12++) {
+                                                            if ( find_6[id12] != 2 ) continue;
+
+                                                            // try swapping non-summed labels 7
+                                                            for (size_t id13 = 0; id13 < labels_7.size(); id13++) {
+                                                                if ( find_7[id13] != 2 ) continue;
+                                                                for (size_t id14 = id13 + 1; id14 < labels_7.size(); id14++) {
+                                                                    if ( find_7[id14] != 2 ) continue;
+
+                                                                    std::shared_ptr<pq> newguy (new pq(vacuum));
+                                                                    newguy->copy((void*)(ordered[i].get()));
+                                                                    newguy->swap_two_labels(labels_1[id1],labels_1[id2]);
+                                                                    newguy->swap_two_labels(labels_2[id3],labels_2[id4]);
+                                                                    newguy->swap_two_labels(labels_3[id5],labels_3[id6]);
+                                                                    newguy->swap_two_labels(labels_4[id7],labels_4[id8]);
+                                                                    newguy->swap_two_labels(labels_5[id9],labels_5[id10]);
+                                                                    newguy->swap_two_labels(labels_6[id11],labels_6[id12]);
+                                                                    newguy->swap_two_labels(labels_7[id13],labels_7[id14]);
+                                                                    strings_same = compare_strings(ordered[j],newguy,n_permute);
+
+                                                                    if ( strings_same ) break;
+                                                                }
+                                                                if ( strings_same ) break;
+                                                            }
+                                                            if ( strings_same ) break;
+                                                        }
+                                                        if ( strings_same ) break;
+                                                    }
+                                                    if ( strings_same ) break;
+                                                }
+                                                if ( strings_same ) break;
+                                            }
+                                            if ( strings_same ) break;
+                                        }
+                                        if ( strings_same ) break;
+                                    }
+                                    if ( strings_same ) break;
+                                }
+                                if ( strings_same ) break;
+                            }
+                            if ( strings_same ) break;
+                        }
+                        if ( strings_same ) break;
+                    }
+                    if ( strings_same ) break;
+                }
+                if ( strings_same ) break;
+            }
+
+            if ( !strings_same ) continue;
+
+            double factor_i = ordered[i]->data->factor * ordered[i]->sign;
+            double factor_j = ordered[j]->data->factor * ordered[j]->sign;
+
+            double combined_factor = factor_i + factor_j * pow(-1.0,n_permute);
+
+            // if terms exactly cancel, do so
+            if ( fabs(combined_factor) < 1e-12 ) {
+                ordered[i]->skip = true;
+                ordered[j]->skip = true;
+                break;
+            }
+
+            // otherwise, combine terms
+            ordered[i]->data->factor = fabs(combined_factor);
+            if ( combined_factor > 0.0 ) {
+                ordered[i]->sign =  1;
+            }else {
+                ordered[i]->sign = -1;
+            }
+            ordered[j]->skip = true;
+
+        }
+    }
+}
+// consolidate terms that differ by six summed labels plus permutations
+void pq::consolidate_permutations_plus_six_swaps(
+    std::vector<std::shared_ptr<pq> > &ordered,
+    std::vector<std::string> labels_1,
+    std::vector<std::string> labels_2, 
+    std::vector<std::string> labels_3,
+    std::vector<std::string> labels_4,
+    std::vector<std::string> labels_5,
+    std::vector<std::string> labels_6) {
+
+    for (size_t i = 0; i < ordered.size(); i++) {
+
+        if ( ordered[i]->skip ) continue;
+
+        std::vector<int> find_1;
+        std::vector<int> find_2;
+        std::vector<int> find_3;
+        std::vector<int> find_4;
+        std::vector<int> find_5;
+        std::vector<int> find_6;
+
+        // ok, what labels do we have? list 1
+        for (size_t j = 0; j < labels_1.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_1[j]);
+            find_1.push_back(found);
+        }
+
+        // ok, what labels do we have? list 2
+        for (size_t j = 0; j < labels_2.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_2[j]);
+            find_2.push_back(found);
+        }
+
+        // ok, what labels do we have? list 3
+        for (size_t j = 0; j < labels_3.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_3[j]);
+            find_3.push_back(found);
+        }
+
+        // ok, what labels do we have? list 4
+        for (size_t j = 0; j < labels_4.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_4[j]);
+            find_4.push_back(found);
+        }
+
+        // ok, what labels do we have? list 5
+        for (size_t j = 0; j < labels_5.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_5[j]);
+            find_5.push_back(found);
+        }
+
+        // ok, what labels do we have? list 6
+        for (size_t j = 0; j < labels_6.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_6[j]);
+            find_6.push_back(found);
+        }
+
+        for (size_t j = i+1; j < ordered.size(); j++) {
+
+            if ( ordered[j]->skip ) continue;
+
+            int n_permute;
+            bool strings_same = compare_strings(ordered[i],ordered[j],n_permute);
+
+            // try swapping non-summed labels 1
+            for (size_t id1 = 0; id1 < labels_1.size(); id1++) {
+                if ( find_1[id1] != 2 ) continue;
+                for (size_t id2 = id1 + 1; id2 < labels_1.size(); id2++) {
+                    if ( find_1[id2] != 2 ) continue;
+
+                    // try swapping non-summed labels 2
+                    for (size_t id3 = 0; id3 < labels_2.size(); id3++) {
+                        if ( find_2[id3] != 2 ) continue;
+                        for (size_t id4 = id3 + 1; id4 < labels_2.size(); id4++) {
+                            if ( find_2[id4] != 2 ) continue;
+
+                            // try swapping non-summed labels 3
+                            for (size_t id5 = 0; id5 < labels_3.size(); id5++) {
+                                if ( find_3[id5] != 2 ) continue;
+                                for (size_t id6 = id5 + 1; id6 < labels_3.size(); id6++) {
+                                    if ( find_3[id6] != 2 ) continue;
+
+                                    // try swapping non-summed labels 4
+                                    for (size_t id7 = 0; id7 < labels_4.size(); id7++) {
+                                        if ( find_4[id7] != 2 ) continue;
+                                        for (size_t id8 = id7 + 1; id8 < labels_4.size(); id8++) {
+                                            if ( find_4[id8] != 2 ) continue;
+
+                                            // try swapping non-summed labels 5
+                                            for (size_t id9 = 0; id9 < labels_5.size(); id9++) {
+                                                if ( find_5[id9] != 2 ) continue;
+                                                for (size_t id10 = id9 + 1; id10 < labels_5.size(); id10++) {
+                                                    if ( find_5[id10] != 2 ) continue;
+
+                                                    // try swapping non-summed labels 6
+                                                    for (size_t id11 = 0; id11 < labels_6.size(); id11++) {
+                                                        if ( find_6[id11] != 2 ) continue;
+                                                        for (size_t id12 = id11 + 1; id12 < labels_6.size(); id12++) {
+                                                            if ( find_6[id12] != 2 ) continue;
+
+                                                            std::shared_ptr<pq> newguy (new pq(vacuum));
+                                                            newguy->copy((void*)(ordered[i].get()));
+                                                            newguy->swap_two_labels(labels_1[id1],labels_1[id2]);
+                                                            newguy->swap_two_labels(labels_2[id3],labels_2[id4]);
+                                                            newguy->swap_two_labels(labels_3[id5],labels_3[id6]);
+                                                            newguy->swap_two_labels(labels_4[id7],labels_4[id8]);
+                                                            newguy->swap_two_labels(labels_5[id9],labels_5[id10]);
+                                                            newguy->swap_two_labels(labels_6[id11],labels_6[id12]);
+                                                            strings_same = compare_strings(ordered[j],newguy,n_permute);
+
+                                                            if ( strings_same ) break;
+                                                        }
+                                                        if ( strings_same ) break;
+                                                    }
+                                                    if ( strings_same ) break;
+                                                }
+                                                if ( strings_same ) break;
+                                            }
+                                            if ( strings_same ) break;
+                                        }
+                                        if ( strings_same ) break;
+                                    }
+                                    if ( strings_same ) break;
+                                }
+                                if ( strings_same ) break;
+                            }
+                            if ( strings_same ) break;
+                        }
+                        if ( strings_same ) break;
+                    }
+                    if ( strings_same ) break;
+                }
+                if ( strings_same ) break;
+            }
+
+            if ( !strings_same ) continue;
+
+            double factor_i = ordered[i]->data->factor * ordered[i]->sign;
+            double factor_j = ordered[j]->data->factor * ordered[j]->sign;
+
+            double combined_factor = factor_i + factor_j * pow(-1.0,n_permute);
+
+            // if terms exactly cancel, do so
+            if ( fabs(combined_factor) < 1e-12 ) {
+                ordered[i]->skip = true;
+                ordered[j]->skip = true;
+                break;
+            }
+
+            // otherwise, combine terms
+            ordered[i]->data->factor = fabs(combined_factor);
+            if ( combined_factor > 0.0 ) {
+                ordered[i]->sign =  1;
+            }else {
+                ordered[i]->sign = -1;
+            }
+            ordered[j]->skip = true;
+
+        }
+    }
+}
+// consolidate terms that differ by five summed labels plus permutations
+void pq::consolidate_permutations_plus_five_swaps(
+    std::vector<std::shared_ptr<pq> > &ordered,
+    std::vector<std::string> labels_1,
+    std::vector<std::string> labels_2, 
+    std::vector<std::string> labels_3,
+    std::vector<std::string> labels_4,
+    std::vector<std::string> labels_5) {
+
+    for (size_t i = 0; i < ordered.size(); i++) {
+
+        if ( ordered[i]->skip ) continue;
+
+        std::vector<int> find_1;
+        std::vector<int> find_2;
+        std::vector<int> find_3;
+        std::vector<int> find_4;
+        std::vector<int> find_5;
+
+        // ok, what labels do we have? list 1
+        for (size_t j = 0; j < labels_1.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_1[j]);
+            find_1.push_back(found);
+        }
+
+        // ok, what labels do we have? list 2
+        for (size_t j = 0; j < labels_2.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_2[j]);
+            find_2.push_back(found);
+        }
+
+        // ok, what labels do we have? list 3
+        for (size_t j = 0; j < labels_3.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_3[j]);
+            find_3.push_back(found);
+        }
+
+        // ok, what labels do we have? list 4
+        for (size_t j = 0; j < labels_4.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_4[j]);
+            find_4.push_back(found);
+        }
+
+        // ok, what labels do we have? list 5
+        for (size_t j = 0; j < labels_5.size(); j++) {
+            int found = ordered[i]->index_in_anywhere(labels_5[j]);
+            find_5.push_back(found);
+        }
+
+        for (size_t j = i+1; j < ordered.size(); j++) {
+
+            if ( ordered[j]->skip ) continue;
+
+            int n_permute;
+            bool strings_same = compare_strings(ordered[i],ordered[j],n_permute);
+
+            // try swapping non-summed labels 1
+            for (size_t id1 = 0; id1 < labels_1.size(); id1++) {
+                if ( find_1[id1] != 2 ) continue;
+                for (size_t id2 = id1 + 1; id2 < labels_1.size(); id2++) {
+                    if ( find_1[id2] != 2 ) continue;
+
+                    // try swapping non-summed labels 2
+                    for (size_t id3 = 0; id3 < labels_2.size(); id3++) {
+                        if ( find_2[id3] != 2 ) continue;
+                        for (size_t id4 = id3 + 1; id4 < labels_2.size(); id4++) {
+                            if ( find_2[id4] != 2 ) continue;
+
+                            // try swapping non-summed labels 3
+                            for (size_t id5 = 0; id5 < labels_3.size(); id5++) {
+                                if ( find_3[id5] != 2 ) continue;
+                                for (size_t id6 = id5 + 1; id6 < labels_3.size(); id6++) {
+                                    if ( find_3[id6] != 2 ) continue;
+
+                                    // try swapping non-summed labels 4
+                                    for (size_t id7 = 0; id7 < labels_4.size(); id7++) {
+                                        if ( find_4[id7] != 2 ) continue;
+                                        for (size_t id8 = id7 + 1; id8 < labels_4.size(); id8++) {
+                                            if ( find_4[id8] != 2 ) continue;
+
+                                            // try swapping non-summed labels 5
+                                            for (size_t id9 = 0; id9 < labels_5.size(); id9++) {
+                                                if ( find_5[id9] != 2 ) continue;
+                                                for (size_t id10 = id9 + 1; id10 < labels_5.size(); id10++) {
+                                                    if ( find_5[id10] != 2 ) continue;
+
+                                                    std::shared_ptr<pq> newguy (new pq(vacuum));
+                                                    newguy->copy((void*)(ordered[i].get()));
+                                                    newguy->swap_two_labels(labels_1[id1],labels_1[id2]);
+                                                    newguy->swap_two_labels(labels_2[id3],labels_2[id4]);
+                                                    newguy->swap_two_labels(labels_3[id5],labels_3[id6]);
+                                                    newguy->swap_two_labels(labels_4[id7],labels_4[id8]);
+                                                    newguy->swap_two_labels(labels_5[id9],labels_5[id10]);
+                                                    strings_same = compare_strings(ordered[j],newguy,n_permute);
+
+                                                    if ( strings_same ) break;
+                                                }
+                                                if ( strings_same ) break;
+                                            }
+                                            if ( strings_same ) break;
+                                        }
+                                        if ( strings_same ) break;
+                                    }
+                                    if ( strings_same ) break;
+                                }
+                                if ( strings_same ) break;
+                            }
+                            if ( strings_same ) break;
+                        }
+                        if ( strings_same ) break;
+                    }
+                    if ( strings_same ) break;
+                }
+                if ( strings_same ) break;
+            }
+
+            if ( !strings_same ) continue;
+
+            double factor_i = ordered[i]->data->factor * ordered[i]->sign;
+            double factor_j = ordered[j]->data->factor * ordered[j]->sign;
+
+            double combined_factor = factor_i + factor_j * pow(-1.0,n_permute);
+
+            // if terms exactly cancel, do so
+            if ( fabs(combined_factor) < 1e-12 ) {
+                ordered[i]->skip = true;
+                ordered[j]->skip = true;
+                break;
+            }
+
+            // otherwise, combine terms
+            ordered[i]->data->factor = fabs(combined_factor);
+            if ( combined_factor > 0.0 ) {
+                ordered[i]->sign =  1;
+            }else {
+                ordered[i]->sign = -1;
+            }
+            ordered[j]->skip = true;
+
+        }
+    }
+}
 
 // consolidate terms that differ by four summed labels plus permutations
 void pq::consolidate_permutations_plus_four_swaps(
@@ -1076,6 +1799,7 @@ void pq::consolidate_permutations_plus_four_swaps(
         }
     }
 }
+
 // consolidate terms that differ by three summed labels plus permutations
 void pq::consolidate_permutations_plus_three_swaps(
     std::vector<std::shared_ptr<pq> > &ordered,

--- a/pdaggerq/pq.cc
+++ b/pdaggerq/pq.cc
@@ -797,7 +797,7 @@ void pq::cleanup(std::vector<std::shared_ptr<pq> > &ordered) {
     consolidate_permutations_plus_two_swaps(ordered,occ_labels,vir_labels);
 
 /*
-    // these don't seem to be necessary for any of the test cases.
+    // these don't seem to be necessary for test cases up to ccsdt
     consolidate_permutations_plus_three_swaps(ordered,occ_labels,occ_labels,occ_labels);
     consolidate_permutations_plus_three_swaps(ordered,occ_labels,occ_labels,vir_labels);
     consolidate_permutations_plus_three_swaps(ordered,occ_labels,vir_labels,vir_labels);

--- a/pdaggerq/pq.cc
+++ b/pdaggerq/pq.cc
@@ -865,6 +865,8 @@ void pq::consolidate_permutations_non_summed(
 
             if ( !already_found ) {
                 find_idx.push_back(found);
+            }else{
+                find_idx.push_back(0);
             }
         }
 
@@ -890,9 +892,41 @@ void pq::consolidate_permutations_non_summed(
                     strings_same = compare_strings(ordered[j],newguy,n_permute);
 
                     if ( strings_same ) {
+
+                        // also need to check if the permutations are the same...
+                        // otherwise, we shouldn't be combining these terms
+                        if ( ordered[i]->data->permutations.size() == ordered[j]->data->permutations.size() ) {
+
+                            // remember, permutations come in pairs
+                            size_t n = data->permutations.size() / 2;
+                            int count = 0;
+                            int n_same = 0;
+                            for (int i = 0; i < n; i++) {
+                                
+                                if ( ordered[i]->data->permutations[count] == ordered[j]->data->permutations[count] ) {
+                                    n_same++;
+                                }else if (  ordered[i]->data->permutations[count]   == ordered[j]->data->permutations[count+1] ) {
+                                    n_same++;
+                                }else if (  ordered[i]->data->permutations[count+1] == ordered[j]->data->permutations[count]   ) {
+                                    n_same++;
+                                }else if (  ordered[i]->data->permutations[count+1] == ordered[j]->data->permutations[count+1] ) {
+                                    n_same++;
+                                }
+                                count += 2;
+
+                            }
+                            if ( n_same != n ) {
+                                continue;
+                            }
+ 
+                        }else {
+                            continue;
+                        }
+                       
                         permutation_1 = labels[id1];
                         permutation_2 = labels[id2];
                         break;
+
                     }
                 }
                 if ( strings_same ) break;

--- a/pdaggerq/pq.h
+++ b/pdaggerq/pq.h
@@ -192,6 +192,50 @@ class pq {
         std::vector<std::string> labels_3,
         std::vector<std::string> labels_4);
 
+    /// consolidate terms that differ by five summed labels plus permutations
+    void consolidate_permutations_plus_five_swaps(
+        std::vector<std::shared_ptr<pq> > &ordered,
+        std::vector<std::string> labels_1,
+        std::vector<std::string> labels_2,
+        std::vector<std::string> labels_3,
+        std::vector<std::string> labels_4, 
+        std::vector<std::string> labels_5);
+
+    /// consolidate terms that differ by six summed labels plus permutations
+    void consolidate_permutations_plus_six_swaps(
+        std::vector<std::shared_ptr<pq> > &ordered,
+        std::vector<std::string> labels_1,
+        std::vector<std::string> labels_2,
+        std::vector<std::string> labels_3,
+        std::vector<std::string> labels_4, 
+        std::vector<std::string> labels_5,
+        std::vector<std::string> labels_6);
+
+    /// consolidate terms that differ by seven summed labels plus permutations
+    void consolidate_permutations_plus_seven_swaps(
+        std::vector<std::shared_ptr<pq> > &ordered,
+        std::vector<std::string> labels_1,
+        std::vector<std::string> labels_2,
+        std::vector<std::string> labels_3,
+        std::vector<std::string> labels_4, 
+        std::vector<std::string> labels_5,
+        std::vector<std::string> labels_6,
+        std::vector<std::string> labels_7);
+
+    /// consolidate terms that differ by eight summed labels plus permutations
+    void consolidate_permutations_plus_eight_swaps(
+        std::vector<std::shared_ptr<pq> > &ordered,
+        std::vector<std::string> labels_1,
+        std::vector<std::string> labels_2,
+        std::vector<std::string> labels_3,
+        std::vector<std::string> labels_4, 
+        std::vector<std::string> labels_5,
+        std::vector<std::string> labels_6,
+        std::vector<std::string> labels_7,
+        std::vector<std::string> labels_8);
+
+    /// consolidate terms that differ by permutations of non-summed labels
+
     /// consolidate terms that differ by permutations of non-summed labels
     void consolidate_permutations_non_summed(
         std::vector<std::shared_ptr<pq> > &ordered,

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2120,17 +2120,16 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
 
     add_operator_product( factor, targets);
     simplify();
-    //printf("done add_operator_product\n");fflush(stdout);
-    //printf("current list size: %zu\n",ordered.size());
-    //print_fully_contracted();
 
     for (int i = 0; i < dim; i++) {
         add_commutator( factor, targets, {ops[i]});
     }
     simplify();
-    //printf("done commutator\n");fflush(stdout);
-    //printf("current list size: %zu\n",ordered.size());
-    //print_fully_contracted();
+
+    // for higher than single commutators, if operators commute, then
+    // we only need to consider unique pairs/triples/quadruplets of
+    // operators. need to add logic to handle cases where the operators
+    // do not commute.
 
     for (int i = 0; i < dim; i++) {
         for (int j = i + 1; j < dim; j++) {
@@ -2143,27 +2142,8 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     }
     simplify();
 
-    //printf("done double_commutator\n");fflush(stdout);
-    //printf("current list size: %zu\n",ordered.size());
-    //print_fully_contracted();
-/*
-     for (int i = 0; i < dim; i++) {
-        for (int j = i; j < dim; j++) {
-            for (int k = j; k < dim; k++) {
-                double scale = 1.0 / 6.0;
-                if      ( i != j && i != k && j != k ) scale = 1.0;
-                else if ( i != j && i != k && j == k ) scale = 0.5;
-                else if ( i != j && i == k && j != k ) scale = 0.5;
-                else if ( i == j && i != k && j != k ) scale = 0.5;
-                add_triple_commutator( scale * factor, targets, {ops[i]}, {ops[j]}, {ops[k]});
-            }
-        }
-    }
-    simplify();
-*/
-
-     // ijk
-     for (int i = 0; i < dim; i++) {
+    // ijk
+    for (int i = 0; i < dim; i++) {
         for (int j = i + 1; j < dim; j++) {
             for (int k = j + 1; k < dim; k++) {
                 add_triple_commutator( factor, targets, {ops[i]}, {ops[j]}, {ops[k]});
@@ -2186,23 +2166,6 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
         add_triple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]});
     }
     simplify();
-
-    //printf("done triple_commutator\n");fflush(stdout);
-    //printf("current list size: %zu\n",ordered.size());
-    //print_fully_contracted();
-
-/*
-    for (int i = 0; i < dim; i++) {
-        for (int j = 0; j < dim; j++) {
-            for (int k = 0 k < dim; k++) {
-                for (int l = 0; l < dim; l++) {
-                    add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
-                }
-            }
-        }
-    }
-    simplify();
-*/
 
     // ijkl
     for (int i = 0; i < dim; i++) {
@@ -2250,11 +2213,6 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
         add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[i]});
     }
     simplify();
-
-    //printf("done quadruple_commutator\n");fflush(stdout);
-    //printf("current list size: %zu\n",ordered.size());
-    //print_fully_contracted();
-
 }
 
 } // End namespaces

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2133,8 +2133,10 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     //print_fully_contracted();
 
     for (int i = 0; i < dim; i++) {
-        for (int j = 0; j < dim; j++) {
-            add_double_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]});
+        for (int j = i; j < dim; j++) {
+            double scale = 0.5;
+            if ( i != j ) scale = 1.0;
+            add_double_commutator( scale * factor, targets, {ops[i]}, {ops[j]});
         }
     }
     simplify();
@@ -2143,9 +2145,14 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     //print_fully_contracted();
 
     for (int i = 0; i < dim; i++) {
-        for (int j = 0; j < dim; j++) {
-            for (int k = 0; k < dim; k++) {
-                add_triple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]});
+        for (int j = i; j < dim; j++) {
+            for (int k = j; k < dim; k++) {
+                double scale = 1.0 / 6.0;
+                if      ( i != j && i != k && j != k ) scale = 1.0;
+                else if ( i != j && i != k && j == k ) scale = 0.5;
+                else if ( i != j && i == k && j != k ) scale = 0.5;
+                else if ( i == j && i != k && j != k ) scale = 0.5;
+                add_triple_commutator( scale * factor, targets, {ops[i]}, {ops[j]}, {ops[k]});
             }
         }
     }
@@ -2155,10 +2162,22 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     //print_fully_contracted();
 
     for (int i = 0; i < dim; i++) {
-        for (int j = 0; j < dim; j++) {
-            for (int k = 0; k < dim; k++) {
-                for (int l = 0; l < dim; l++) {
-                    add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
+        for (int j = i; j < dim; j++) {
+            for (int k = j; k < dim; k++) {
+                for (int l = k; l < dim; l++) {
+                    double scale = 1.0 / 24.0;
+                    if      ( i != j && i != k && j != k && j != l) scale = 1.0;
+                    if      ( i != j && i != k && j != k && j == l) scale = 1.0 / 6.0;
+                    if      ( i != j && i != k && j == k && j != l) scale = 1.0 / 6.0;
+                    if      ( i != j && i == k && j != k && j != l) scale = 1.0 / 6.0;
+                    if      ( i == j && i != k && j != k && j != l) scale = 1.0 / 6.0;
+                    if      ( i != j && i != k && j == k && j == l) scale = 0.5;
+                    if      ( i != j && i == k && j != k && j == l) scale = 0.5;
+                    if      ( i == j && i != k && j != k && j == l) scale = 0.5;
+                    if      ( i != j && i == k && j == k && j != l) scale = 0.5;
+                    if      ( i == j && i != k && j == k && j != l) scale = 0.5;
+                    if      ( i == j && i == k && j != k && j != l) scale = 0.5;
+                    add_quadruple_commutator( scale * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
                 }
             }
         }

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2133,11 +2133,13 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     //print_fully_contracted();
 
     for (int i = 0; i < dim; i++) {
-        for (int j = i; j < dim; j++) {
-            double scale = 0.5;
-            if ( i != j ) scale = 1.0;
-            add_double_commutator( scale * factor, targets, {ops[i]}, {ops[j]});
+        for (int j = i + 1; j < dim; j++) {
+            add_double_commutator(factor, targets, {ops[i]}, {ops[j]});
         }
+    }
+    simplify();
+    for (int i = 0; i < dim; i++) {
+        add_double_commutator(0.5 * factor, targets, {ops[i]}, {ops[i]});
     }
     simplify();
 
@@ -2171,9 +2173,9 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
 
     // ijj
     for (int i = 0; i < dim; i++) {
-        for (int j = 0; j < dim; j++) {
-            if ( i == j ) continue;
+        for (int j = i + 1; j < dim; j++) {
             add_triple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]});
+            add_triple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]});
         }
     }
     simplify();
@@ -2203,9 +2205,10 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     // ijkk
     for (int i = 0; i < dim; i++) {
         for (int j = i + 1; j < dim; j++) {
-            for (int k = 0; k < dim; k++) {
-                if ( k == i || k == j ) continue;
+            for (int k = j + 1; k < dim; k++) {
                 add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[k]});
+                add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]}, {ops[k]});
+                add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]}, {ops[k]});
             }
         }
     }
@@ -2221,9 +2224,9 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
 
     // iiij
     for (int i = 0; i < dim; i++) {
-        for (int j = 0; j < dim; j++) {
-            if ( i == j ) continue;
+        for (int j = i + 1; j < dim; j++) {
             add_quadruple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[j]});
+            add_quadruple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]}, {ops[j]});
         }
     }
     simplify();

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -1610,6 +1610,7 @@ void pq_helper::add_new_string_fermi_vacuum(){
         n_gen_idx = 1;
     }
 
+    //printf("current list size: %zu\n",ordered.size());
     for (int string_num = 0; string_num < n_gen_idx * n_gen_idx; string_num++) {
 
         // factors:
@@ -1963,7 +1964,9 @@ void pq_helper::add_new_string_fermi_vacuum(){
             }
             tmp.clear();
             for (int i = 0; i < (int)list.size(); i++) {
-                tmp.push_back(list[i]);
+                if ( !list[i]->skip ) {
+                    tmp.push_back(list[i]);
+                }
             }
         }while(!done_rearranging);
 
@@ -1971,6 +1974,7 @@ void pq_helper::add_new_string_fermi_vacuum(){
         for (int i = 0; i < (int)tmp.size(); i++) {
             ordered.push_back(tmp[i]);
         }
+        //printf("current list size: %zu\n",ordered.size());
         tmp.clear();
 
     }
@@ -2002,8 +2006,8 @@ void pq_helper::simplify() {
 
         if ( ordered[i]->skip ) continue;
 
-        // check for occ/vir pairs in delta functions
-        ordered[i]->check_occ_vir();
+        // check for occ/vir pairs in delta functions ... i think this is handled by the normal order procedure
+        //ordered[i]->check_occ_vir();
 
         // apply delta functions
         ordered[i]->gobble_deltas();
@@ -2019,7 +2023,7 @@ void pq_helper::simplify() {
 
     // try to cancel similar terms
     mystring->cleanup(ordered);
-    
+
 }
 
 void pq_helper::print_two_body() {
@@ -2115,16 +2119,29 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     int dim = (int)ops.size();
 
     add_operator_product( factor, targets);
+    simplify();
+    //printf("done add_operator_product\n");fflush(stdout);
+    //printf("current list size: %zu\n",ordered.size());
+    //print_fully_contracted();
 
     for (int i = 0; i < dim; i++) {
         add_commutator( factor, targets, {ops[i]});
     }
+    simplify();
+    //printf("done commutator\n");fflush(stdout);
+    //printf("current list size: %zu\n",ordered.size());
+    //print_fully_contracted();
 
     for (int i = 0; i < dim; i++) {
         for (int j = 0; j < dim; j++) {
             add_double_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]});
         }
     }
+    simplify();
+    //printf("done double_commutator\n");fflush(stdout);
+    //printf("current list size: %zu\n",ordered.size());
+    //print_fully_contracted();
+
     for (int i = 0; i < dim; i++) {
         for (int j = 0; j < dim; j++) {
             for (int k = 0; k < dim; k++) {
@@ -2132,6 +2149,11 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
             }
         }
     }
+    simplify();
+    //printf("done triple_commutator\n");fflush(stdout);
+    //printf("current list size: %zu\n",ordered.size());
+    //print_fully_contracted();
+
     for (int i = 0; i < dim; i++) {
         for (int j = 0; j < dim; j++) {
             for (int k = 0; k < dim; k++) {
@@ -2141,6 +2163,10 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
             }
         }
     }
+    simplify();
+    //printf("done quadruple_commutator\n");fflush(stdout);
+    //printf("current list size: %zu\n",ordered.size());
+    //print_fully_contracted();
 
 }
 

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2161,6 +2161,7 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     }
     simplify();
 */
+
      // ijk
      for (int i = 0; i < dim; i++) {
         for (int j = i + 1; j < dim; j++) {
@@ -2189,6 +2190,19 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     //printf("done triple_commutator\n");fflush(stdout);
     //printf("current list size: %zu\n",ordered.size());
     //print_fully_contracted();
+
+/*
+    for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+            for (int k = 0 k < dim; k++) {
+                for (int l = 0; l < dim; l++) {
+                    add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
+                }
+            }
+        }
+    }
+    simplify();
+*/
 
     // ijkl
     for (int i = 0; i < dim; i++) {

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2140,11 +2140,12 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
         }
     }
     simplify();
+
     //printf("done double_commutator\n");fflush(stdout);
     //printf("current list size: %zu\n",ordered.size());
     //print_fully_contracted();
-
-    for (int i = 0; i < dim; i++) {
+/*
+     for (int i = 0; i < dim; i++) {
         for (int j = i; j < dim; j++) {
             for (int k = j; k < dim; k++) {
                 double scale = 1.0 / 6.0;
@@ -2157,10 +2158,37 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
         }
     }
     simplify();
+*/
+     // ijk
+     for (int i = 0; i < dim; i++) {
+        for (int j = i + 1; j < dim; j++) {
+            for (int k = j + 1; k < dim; k++) {
+                add_triple_commutator( factor, targets, {ops[i]}, {ops[j]}, {ops[k]});
+            }
+        }
+    }
+    simplify();
+
+    // ijj
+    for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+            if ( i == j ) continue;
+            add_triple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]});
+        }
+    }
+    simplify();
+
+     // iii
+    for (int i = 0; i < dim; i++) {
+        add_triple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]});
+    }
+    simplify();
+
     //printf("done triple_commutator\n");fflush(stdout);
     //printf("current list size: %zu\n",ordered.size());
     //print_fully_contracted();
 
+    // ijkl
     for (int i = 0; i < dim; i++) {
         for (int j = i + 1; j < dim; j++) {
             for (int k = j + 1; k < dim; k++) {
@@ -2171,30 +2199,41 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
         }
     }
     simplify();
+
+    // ijkk
     for (int i = 0; i < dim; i++) {
         for (int j = i + 1; j < dim; j++) {
-            for (int k = j + 1; k < dim; k++) {
+            for (int k = 0; k < dim; k++) {
+                if ( k == i || k == j ) continue;
                 add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[k]});
             }
         }
     }
     simplify();
+
+    // iijj
     for (int i = 0; i < dim; i++) {
         for (int j = i + 1; j < dim; j++) {
             add_quadruple_commutator( 0.25 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]}, {ops[j]});
         }
     }
     simplify();
+
+    // iiij
     for (int i = 0; i < dim; i++) {
-        for (int j = i + 1; j < dim; j++) {
+        for (int j = 0; j < dim; j++) {
+            if ( i == j ) continue;
             add_quadruple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[j]});
         }
     }
     simplify();
+
+    // iiii
     for (int i = 0; i < dim; i++) {
         add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[i]});
     }
     simplify();
+
     //printf("done quadruple_commutator\n");fflush(stdout);
     //printf("current list size: %zu\n",ordered.size());
     //print_fully_contracted();

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2162,25 +2162,37 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     //print_fully_contracted();
 
     for (int i = 0; i < dim; i++) {
-        for (int j = i; j < dim; j++) {
-            for (int k = j; k < dim; k++) {
-                for (int l = k; l < dim; l++) {
-                    double scale = 1.0 / 24.0;
-                    if      ( i != j && i != k && j != k && j != l) scale = 1.0;
-                    if      ( i != j && i != k && j != k && j == l) scale = 1.0 / 6.0;
-                    if      ( i != j && i != k && j == k && j != l) scale = 1.0 / 6.0;
-                    if      ( i != j && i == k && j != k && j != l) scale = 1.0 / 6.0;
-                    if      ( i == j && i != k && j != k && j != l) scale = 1.0 / 6.0;
-                    if      ( i != j && i != k && j == k && j == l) scale = 0.5;
-                    if      ( i != j && i == k && j != k && j == l) scale = 0.5;
-                    if      ( i == j && i != k && j != k && j == l) scale = 0.5;
-                    if      ( i != j && i == k && j == k && j != l) scale = 0.5;
-                    if      ( i == j && i != k && j == k && j != l) scale = 0.5;
-                    if      ( i == j && i == k && j != k && j != l) scale = 0.5;
-                    add_quadruple_commutator( scale * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
+        for (int j = i + 1; j < dim; j++) {
+            for (int k = j + 1; k < dim; k++) {
+                for (int l = k + 1; l < dim; l++) {
+                    add_quadruple_commutator( factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
                 }
             }
         }
+    }
+    simplify();
+    for (int i = 0; i < dim; i++) {
+        for (int j = i + 1; j < dim; j++) {
+            for (int k = j + 1; k < dim; k++) {
+                add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[k]});
+            }
+        }
+    }
+    simplify();
+    for (int i = 0; i < dim; i++) {
+        for (int j = i + 1; j < dim; j++) {
+            add_quadruple_commutator( 0.25 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]}, {ops[j]});
+        }
+    }
+    simplify();
+    for (int i = 0; i < dim; i++) {
+        for (int j = i + 1; j < dim; j++) {
+            add_quadruple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[j]});
+        }
+    }
+    simplify();
+    for (int i = 0; i < dim; i++) {
+        add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[i]});
     }
     simplify();
     //printf("done quadruple_commutator\n");fflush(stdout);

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -62,6 +62,7 @@ void export_pq_helper(py::module& m) {
         .def("set_left_operators", &pq_helper::set_left_operators)
         .def("set_right_operators", &pq_helper::set_right_operators)
         .def("set_factor", &pq_helper::set_factor)
+        .def("set_cluster_operators_commute", &pq_helper::set_cluster_operators_commute)
         .def("add_new_string", &pq_helper::add_new_string)
         .def("add_operator_product", &pq_helper::add_operator_product)
         .def("add_st_operator", &pq_helper::add_st_operator)
@@ -123,6 +124,10 @@ pq_helper::pq_helper(std::string vacuum_type)
     ket = "VACUUM";
 
     print_level = 0;
+
+    // assume operators entering a similarity transformation
+    // commute. only relevant for the add_st_operator() function
+    cluster_operators_commute_ = true;
 
 }
 
@@ -2130,89 +2135,127 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
     // we only need to consider unique pairs/triples/quadruplets of
     // operators. need to add logic to handle cases where the operators
     // do not commute.
+    if ( cluster_operators_commute_ ) {
 
-    for (int i = 0; i < dim; i++) {
-        for (int j = i + 1; j < dim; j++) {
-            add_double_commutator(factor, targets, {ops[i]}, {ops[j]});
-        }
-    }
-    simplify();
-    for (int i = 0; i < dim; i++) {
-        add_double_commutator(0.5 * factor, targets, {ops[i]}, {ops[i]});
-    }
-    simplify();
-
-    // ijk
-    for (int i = 0; i < dim; i++) {
-        for (int j = i + 1; j < dim; j++) {
-            for (int k = j + 1; k < dim; k++) {
-                add_triple_commutator( factor, targets, {ops[i]}, {ops[j]}, {ops[k]});
+        for (int i = 0; i < dim; i++) {
+            for (int j = i + 1; j < dim; j++) {
+                add_double_commutator(factor, targets, {ops[i]}, {ops[j]});
             }
         }
-    }
-    simplify();
-
-    // ijj
-    for (int i = 0; i < dim; i++) {
-        for (int j = i + 1; j < dim; j++) {
-            add_triple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]});
-            add_triple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]});
+        simplify();
+        for (int i = 0; i < dim; i++) {
+            add_double_commutator(0.5 * factor, targets, {ops[i]}, {ops[i]});
         }
-    }
-    simplify();
+        simplify();
 
-     // iii
-    for (int i = 0; i < dim; i++) {
-        add_triple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]});
-    }
-    simplify();
-
-    // ijkl
-    for (int i = 0; i < dim; i++) {
-        for (int j = i + 1; j < dim; j++) {
-            for (int k = j + 1; k < dim; k++) {
-                for (int l = k + 1; l < dim; l++) {
-                    add_quadruple_commutator( factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
+        // ijk
+        for (int i = 0; i < dim; i++) {
+            for (int j = i + 1; j < dim; j++) {
+                for (int k = j + 1; k < dim; k++) {
+                    add_triple_commutator( factor, targets, {ops[i]}, {ops[j]}, {ops[k]});
                 }
             }
         }
-    }
-    simplify();
+        simplify();
 
-    // ijkk
-    for (int i = 0; i < dim; i++) {
-        for (int j = i + 1; j < dim; j++) {
-            for (int k = j + 1; k < dim; k++) {
-                add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[k]});
-                add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]}, {ops[k]});
-                add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]}, {ops[k]});
+        // ijj
+        for (int i = 0; i < dim; i++) {
+            for (int j = i + 1; j < dim; j++) {
+                add_triple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]});
+                add_triple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]});
             }
         }
-    }
-    simplify();
+        simplify();
 
-    // iijj
-    for (int i = 0; i < dim; i++) {
-        for (int j = i + 1; j < dim; j++) {
-            add_quadruple_commutator( 0.25 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]}, {ops[j]});
+         // iii
+        for (int i = 0; i < dim; i++) {
+            add_triple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]});
         }
-    }
-    simplify();
+        simplify();
 
-    // iiij
-    for (int i = 0; i < dim; i++) {
-        for (int j = i + 1; j < dim; j++) {
-            add_quadruple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[j]});
-            add_quadruple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]}, {ops[j]});
+        // ijkl
+        for (int i = 0; i < dim; i++) {
+            for (int j = i + 1; j < dim; j++) {
+                for (int k = j + 1; k < dim; k++) {
+                    for (int l = k + 1; l < dim; l++) {
+                        add_quadruple_commutator( factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
+                    }
+                }
+            }
         }
-    }
-    simplify();
+        simplify();
 
-    // iiii
-    for (int i = 0; i < dim; i++) {
-        add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[i]});
+        // ijkk
+        for (int i = 0; i < dim; i++) {
+            for (int j = i + 1; j < dim; j++) {
+                for (int k = j + 1; k < dim; k++) {
+                    add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[k]});
+                    add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]}, {ops[k]});
+                    add_quadruple_commutator( 0.5 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]}, {ops[k]});
+                }
+            }
+        }
+        simplify();
+
+        // iijj
+        for (int i = 0; i < dim; i++) {
+            for (int j = i + 1; j < dim; j++) {
+                add_quadruple_commutator( 0.25 * factor, targets, {ops[i]}, {ops[i]}, {ops[j]}, {ops[j]});
+            }
+        }
+        simplify();
+
+        // iiij
+        for (int i = 0; i < dim; i++) {
+            for (int j = i + 1; j < dim; j++) {
+                add_quadruple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[j]});
+                add_quadruple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[j]}, {ops[j]});
+            }
+        }
+        simplify();
+
+        // iiii
+        for (int i = 0; i < dim; i++) {
+            add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[i]}, {ops[i]}, {ops[i]});
+        }
+        simplify();
+    }else {
+
+        for (int i = 0; i < dim; i++) {
+            for (int j = 0; j < dim; j++) {
+                add_double_commutator( 0.5 * factor, targets, {ops[i]}, {ops[j]});
+            }
+        }
+        simplify();
+
+        for (int i = 0; i < dim; i++) {
+            for (int j = 0; j < dim; j++) {
+                for (int k = 0; k < dim; k++) {
+                    add_triple_commutator( 1.0 / 6.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]});
+                }
+            }
+        }
+        simplify();
+
+        for (int i = 0; i < dim; i++) {
+            for (int j = 0; j < dim; j++) {
+                for (int k = 0; k < dim; k++) {
+                    for (int l = 0; l < dim; l++) {
+                        add_quadruple_commutator( 1.0 / 24.0 * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
+                    }
+                }
+            }
+        }
+        simplify();
+
     }
-    simplify();
+}
+
+// do operators entering similarity transformation commute? default true
+void pq_helper::set_cluster_operators_commute(bool cluster_operators_commute) {
+
+    cluster_operators_commute_ = cluster_operators_commute;
+
 }
 
 } // End namespaces

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2166,17 +2166,45 @@ void pq_helper::add_st_operator(double factor, std::vector<std::string> targets,
             for (int k = j; k < dim; k++) {
                 for (int l = k; l < dim; l++) {
                     double scale = 1.0 / 24.0;
-                    if      ( i != j && i != k && j != k && j != l) scale = 1.0;
-                    if      ( i != j && i != k && j != k && j == l) scale = 1.0 / 6.0;
-                    if      ( i != j && i != k && j == k && j != l) scale = 1.0 / 6.0;
-                    if      ( i != j && i == k && j != k && j != l) scale = 1.0 / 6.0;
-                    if      ( i == j && i != k && j != k && j != l) scale = 1.0 / 6.0;
-                    if      ( i != j && i != k && j == k && j == l) scale = 0.5;
-                    if      ( i != j && i == k && j != k && j == l) scale = 0.5;
-                    if      ( i == j && i != k && j != k && j == l) scale = 0.5;
-                    if      ( i != j && i == k && j == k && j != l) scale = 0.5;
-                    if      ( i == j && i != k && j == k && j != l) scale = 0.5;
-                    if      ( i == j && i == k && j != k && j != l) scale = 0.5;
+
+                    if      ( i != j && i != k && i != l && j != k && j != l && k != l) scale = 1.0;
+
+                    if      ( i != j && i != k && i != l && j != k && j != l && k == l) scale = 0.5;
+                    if      ( i != j && i != k && i != l && j != k && j == l && k != l) scale = 0.5;
+                    if      ( i != j && i != k && i != l && j == k && j != l && k != l) scale = 0.5;
+                    if      ( i != j && i != k && i == l && j != k && j != l && k != l) scale = 0.5;
+                    if      ( i != j && i == k && i != l && j != k && j != l && k != l) scale = 0.5;
+                    if      ( i == j && i != k && i != l && j != k && j != l && k != l) scale = 0.5;
+
+                    //if      ( i != j && i != k && i != l && j != k && j == l && k == l) scale = 1.0 / 6.0;
+                    //if      ( i != j && i != k && i != l && j == k && j != l && k == l) scale = 1.0 / 6.0;
+                    //if      ( i != j && i != k && i == l && j != k && j != l && k == l) scale = 1.0 / 6.0;
+                    //if      ( i != j && i == k && i != l && j != k && j != l && k == l) scale = 1.0 / 6.0;
+                    //if      ( i == j && i != k && i != l && j != k && j != l && k == l) scale = 1.0 / 6.0;
+                    //if      ( i != j && i != k && i != l && j == k && j == l && k != l) scale = 1.0 / 6.0;
+                    //if      ( i != j && i != k && i == l && j != k && j == l && k != l) scale = 1.0 / 6.0;
+                    //if      ( i != j && i == k && i != l && j != k && j == l && k != l) scale = 1.0 / 6.0;
+                    //if      ( i == j && i != k && i != l && j != k && j == l && k != l) scale = 1.0 / 6.0;
+                    //if      ( i != j && i != k && i == l && j == k && j != l && k != l) scale = 1.0 / 6.0;
+                    //if      ( i != j && i == k && i != l && j == k && j != l && k != l) scale = 1.0 / 6.0;
+                    //if      ( i == j && i != k && i != l && j == k && j != l && k != l) scale = 1.0 / 6.0;
+
+                    if      ( i != j && i == k && i == l) scale = 1.0 / 6.0;
+                    if      ( i == j && i != k && i == l) scale = 1.0 / 6.0;
+                    if      ( i == j && i == k && i != l) scale = 1.0 / 6.0;
+
+                    if      ( j != i && j == k && j == l) scale = 1.0 / 6.0;
+                    if      ( j == i && j != k && j == l) scale = 1.0 / 6.0;
+                    if      ( j == i && j == k && j != l) scale = 1.0 / 6.0;
+
+                    if      ( k != i && k == j && k == l) scale = 1.0 / 6.0;
+                    if      ( k == i && k != j && k == l) scale = 1.0 / 6.0;
+                    if      ( k == i && k == j && k != l) scale = 1.0 / 6.0;
+
+                    if      ( l != i && l == j && l == l) scale = 1.0 / 6.0;
+                    if      ( l == i && l != j && l == l) scale = 1.0 / 6.0;
+                    if      ( l == i && l == j && l != l) scale = 1.0 / 6.0;
+
                     add_quadruple_commutator( scale * factor, targets, {ops[i]}, {ops[j]}, {ops[k]}, {ops[l]});
                 }
             }

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -57,6 +57,8 @@ class pq_helper {
     /// operators to apply to the right of any operator products we add
     std::vector<std::string> right_operators;
 
+    /// do operators entering a similarity transformation commute?
+    bool cluster_operators_commute_;
 
   public:
 
@@ -170,6 +172,8 @@ class pq_helper {
     /// print two-body strings
     void print_two_body();
 
+    /// do operators entering similarity transformation commute? default true
+    void set_cluster_operators_commute(bool cluster_operators_commute);
 };
 
 }


### PR DESCRIPTION
Lots of changes speed up the code and dramatically reduce its memory requirements:

- add_st_operator() automatically calls simplify() after some class of commutators is evaluated
- for normal order wrt Fermi vacuum, don't store strings that won't be included in the list of fully contracted strings
- for operators entering add_st_operator() that commute, only compute non-redundant commutators. this is the default behavior (ie, it is assumed that these operators commute). a new function allows the user to turn this feature off
- modifications to simplify() function so that it is safe to call it repeatedly.
- adds functions to compare strings when swapping up to 8 summation labels. only two swaps seem necessary for all tests (up to ccsdtq), so none of the 3-8 swaps are actually in use currently