### PR TITLE
Update tests to reflect required spin string in BaseTerm

### DIFF
--- a/pdaggerq/algebra.py
+++ b/pdaggerq/algebra.py
@@ -93,6 +93,12 @@ class BaseTerm:
 
     These objects one can ONLY be composed by multiplication with other BaseTerms
     to produce new TensorTerms.  They can also be checked for equality.
+
+    :param indices: Tuple[Index, ...], tuple of indices for the tensor
+    :param str name: name of the tensor
+    :param str spin: spin sector associated with tensor. if spin orbital than leave as
+                     an empty string ``.  the alpha-alpha block is `_aa`, beta-beta block
+                     is `_bb`. etc.  Always start string with an underscore unless empty.
     """
 
     def __init__(self, *, indices: Tuple[Index, ...], name: str, spin: str):

--- a/pdaggerq/algebra_test.py
+++ b/pdaggerq/algebra_test.py
@@ -40,12 +40,12 @@ def test_index():
 
 def test_baseterm():
     term = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='h')
+                    name='h', spin='')
     assert term.indices[0] == Index('i', 'occ')
     assert term.indices[1] == Index('j', 'occ')
 
     term2 = BaseTerm(indices=(Index('k', 'occ'), Index('l', 'occ')),
-                    name='t1')
+                    name='t1', spin='')
     tensort = term2 * term
     assert isinstance(tensort, TensorTerm)
 
@@ -58,22 +58,30 @@ def test_baseterm():
 
 def test_tensorterm():
     hij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='h')
+                    name='h', spin='')
     t1ij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='t')
+                    name='t', spin='')
     tensor_term = TensorTerm(base_terms=(hij, t1ij))
     assert tensor_term.coefficient == 1.0
 
     assert tensor_term.__repr__() == " 1.0000 h(i,j)*t(i,j)"
 
+    hij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
+                    name='h', spin='_aa')
+    t1ij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
+                    name='t', spin='_aa')
+    tensor_term = TensorTerm(base_terms=(hij, t1ij))
+    assert tensor_term.coefficient == 1.0
+
+    assert tensor_term.__repr__() == " 1.0000 h_aa(i,j)*t_aa(i,j)"
+
 
 def test_tensor_multiply():
     hij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='h')
+                    name='h', spin='')
     t1ij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='t')
+                    name='t', spin='')
     tensor_term = TensorTerm(base_terms=(hij, t1ij))
-
     test_tensor_term = tensor_term * 4
     assert isinstance(test_tensor_term, TensorTerm)
     assert np.isclose(test_tensor_term.coefficient, 4)
@@ -83,7 +91,7 @@ def test_tensor_multiply():
     assert np.isclose(test_tensor_term.coefficient, 4)
 
     t1kl = BaseTerm(indices=(Index('k', 'occ'), Index('l', 'virt')),
-                    name='t')
+                    name='t', spin='')
     test_tensor_term = tensor_term * t1kl
     assert test_tensor_term.base_terms[2] == t1kl
 

--- a/pdaggerq/parser.py
+++ b/pdaggerq/parser.py
@@ -328,7 +328,8 @@ def string_to_baseterm(term_string, occ_idx=OCC_INDICES, virt_idx=VIRT_INDICES):
 
 def contracted_strings_to_tensor_terms(pdaggerq_list_of_strings):
     """
-    Take the output from pdaggerq.fully_contracted_strings() and generate
+    Take the output from pdaggerq.fully_contracted_strings() or
+    pdaggerq.fully_contracted_strings_spin() and generate
     TensorTerms
 
     :param pdaggerq_list_of_strings: List[List[str]] where the first item is

--- a/pdaggerq/parser_test.py
+++ b/pdaggerq/parser_test.py
@@ -30,8 +30,8 @@ def test_parse_strings_to_tensor():
    energy_tensor_terms = contracted_strings_to_tensor_terms(energy_strings)
    i, j, a, b = Index('i', 'occ'), Index('j', 'occ'), Index('a', 'virt'), Index(
       'b', 'virt')
-   h_ii = BaseTerm(indices=(i, i), name='f')
-   f_ia = BaseTerm(indices=(i, a), name='f')
+   h_ii = BaseTerm(indices=(i, i), name='f', spin='')
+   f_ia = BaseTerm(indices=(i, a), name='f', spin='')
    t1 = T1amps(indices=(a, i))
    g_ijab = TwoBody(indices=(i, j, a, b), name='g')
    t2_abij = T2amps(indices=(a, b, j, i), name='t2')


### PR DESCRIPTION
BaseTerm now must be initialized with a spin string.

Tests needed to be updated to reflect this. An empty string is sufficient to indicate the spin-orbital case.