### PR TITLE
Triples permutations

### DIFF
--- a/pdaggerq/algebra.py
+++ b/pdaggerq/algebra.py
@@ -288,6 +288,9 @@ class TensorTerm:
                 einsum_tensors) + ")"
         if update_val is not None and self.actions is None:
             teinsum_string = update_val + " " + '+' + teinsum_string
+
+        # TODO: need logic for paired permutations PP2(ia,jb), PP3(ia,jb,kc), and PP6(ia,jb,kc)
+
         elif update_val is not None and self.actions is not None:
             # now generate logic for single permutation
             original_out = list(filter(None,
@@ -539,3 +542,27 @@ class ContractionPermuter(TensorTermAction):
 
     def __repr__(self):
         return "P({},{})".format(self.indices[0], self.indices[1])
+
+class ContractionPairPermuter6(TensorTermAction):
+
+    def __init__(self, *, spin='', indices=Tuple[Index, ...], name='PP6'):
+        super().__init__(indices=indices, name=name, spin=spin)
+
+    def __repr__(self):
+        return "PP6({},{},{},{},{},{})".format(self.indices[0], self.indices[1], self.indices[2], self.indices[3], self.indices[4], self.indices[5])
+
+class ContractionPairPermuter2(TensorTermAction):
+
+    def __init__(self, *, spin='', indices=Tuple[Index, ...], name='PP2'):
+        super().__init__(indices=indices, name=name, spin=spin)
+
+    def __repr__(self):
+        return "PP2({},{},{},{})".format(self.indices[0], self.indices[1], self.indices[2], self.indices[3])
+
+class ContractionPairPermuter3(TensorTermAction):
+
+    def __init__(self, *, spin='', indices=Tuple[Index, ...], name='PP3'):
+        super().__init__(indices=indices, name=name, spin=spin)
+
+    def __repr__(self):
+        return "PP3({},{},{},{},{},{})".format(self.indices[0], self.indices[1], self.indices[2], self.indices[3], self.indices[4], self.indices[5])

--- a/pdaggerq/parser.py
+++ b/pdaggerq/parser.py
@@ -19,7 +19,9 @@ from pdaggerq.algebra import (OneBody, TwoBody, T1amps, T2amps, T3amps, T4amps,
                               Left2amps, Left3amps, Left4amps, Right0amps,
                               Right1amps, Right2amps, Right3amps, Right4amps,
                               FockMat, BaseTerm, ContractionPermuter,
-                              TensorTermAction, )
+                              FockMat, BaseTerm, ContractionPermuter, 
+                              ContractionPairPermuter3, ContractionPairPermuter6,
+                              ContractionPairPermuter2, TensorTermAction, )
 from pdaggerq.config import OCC_INDICES, VIRT_INDICES
 
 
@@ -322,6 +324,21 @@ def string_to_baseterm(term_string, occ_idx=OCC_INDICES, virt_idx=VIRT_INDICES):
         g_idx = [Index(xx, 'occ') if xx in occ_idx else Index(xx, 'virt') for xx
                  in index_string.split(',')]
         return ContractionPermuter(indices=tuple(g_idx))
+    elif 'PP2(' in term_string:
+        index_string = term_string.replace('PP2(', '').replace(')', '')
+        g_idx = [Index(xx, 'occ') if xx in occ_idx else Index(xx, 'virt') for xx
+                 in index_string.split(',')]
+        return ContractionPairPermuter2(indices=tuple(g_idx))
+    elif 'PP3(' in term_string:
+        index_string = term_string.replace('PP3(', '').replace(')', '')
+        g_idx = [Index(xx, 'occ') if xx in occ_idx else Index(xx, 'virt') for xx
+                 in index_string.split(',')]
+        return ContractionPairPermuter3(indices=tuple(g_idx))
+    elif 'PP6(' in term_string:
+        index_string = term_string.replace('PP6(', '').replace(')', '')
+        g_idx = [Index(xx, 'occ') if xx in occ_idx else Index(xx, 'virt') for xx
+                 in index_string.split(',')]
+        return ContractionPairPermuter6(indices=tuple(g_idx))
     else:
         raise TypeError("{} not recognized".format(term_string))
 
@@ -329,7 +346,7 @@ def string_to_baseterm(term_string, occ_idx=OCC_INDICES, virt_idx=VIRT_INDICES):
 def contracted_strings_to_tensor_terms(pdaggerq_list_of_strings):
     """
     Take the output from pdaggerq.fully_contracted_strings() or
-    pdaggerq.fully_contracted_strings_spin() and generate
+    pdaggerq.fully_contracted_strings_with_spin() and generate
     TensorTerms
 
     :param pdaggerq_list_of_strings: List[List[str]] where the first item is

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -60,6 +60,7 @@ void export_pq_helper(py::module& m) {
         .def("set_left_operators_type", &pq_helper::set_left_operators_type)
         .def("set_right_operators_type", &pq_helper::set_right_operators_type)
         .def("set_cluster_operators_commute", &pq_helper::set_cluster_operators_commute)
+        .def("set_find_paired_permutations", &pq_helper::set_find_paired_permutations)
         .def("simplify", &pq_helper::simplify)
         .def("clear", &pq_helper::clear)
         .def("print",
@@ -110,6 +111,9 @@ pq_helper::pq_helper(std::string vacuum_type)
     // commute. only relevant for the add_st_operator() function
     cluster_operators_commute = true;
 
+    // by default, do not look for paired permutations (until parsers catch up)
+    find_paired_permutations = false;
+
     /// right operators type (EE, IP, EA)
     right_operators_type = "EE";
 
@@ -120,6 +124,10 @@ pq_helper::pq_helper(std::string vacuum_type)
 
 pq_helper::~pq_helper()
 {
+}
+
+void pq_helper::set_find_paired_permutations(bool do_find_paired_permutations) {
+    find_paired_permutations = do_find_paired_permutations;
 }
 
 void pq_helper::set_print_level(int level) {
@@ -1053,9 +1061,9 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
             newguy->has_w0 = has_w0;
 
             if ( vacuum == "TRUE" ) {
-                add_new_string_true_vacuum(newguy, ordered, print_level);
+                add_new_string_true_vacuum(newguy, ordered, print_level, find_paired_permutations);
             }else {
-                add_new_string_fermi_vacuum(newguy, ordered, print_level);
+                add_new_string_fermi_vacuum(newguy, ordered, print_level, find_paired_permutations);
             }
         }
     }
@@ -1081,7 +1089,7 @@ void pq_helper::simplify() {
     }
 
     // try to cancel similar terms
-    cleanup(ordered);
+    cleanup(ordered, find_paired_permutations);
 
 }
 

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -69,7 +69,6 @@ void export_pq_helper(py::module& m) {
              py::arg("string_type") = "fully-contracted" )
         .def("strings", &pq_helper::strings)
         .def("fully_contracted_strings", &pq_helper::fully_contracted_strings)
-        .def("fully_contracted_strings_with_spin", &pq_helper::fully_contracted_strings_with_spin)
         .def("fully_contracted_strings_with_spin",
              [](pq_helper& self, std::map<std::string, std::string> spin_labels) {
                  return self.fully_contracted_strings_with_spin(spin_labels);

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -88,10 +88,19 @@ class pq_helper {
      *
      * set whether operators entering similarity transformation commute
      *
-     * @param do_cluster_operators_commute: true/false (default true)
+     * @param do_cluster_operators_commute: true/false
      *
      */
     void set_cluster_operators_commute(bool do_cluster_operators_commute);
+
+    /**
+     *
+     * set whether we should search for paired ov permutations that arise in ccsdt
+     *
+     * @param do_find_paired_permutations: true/false
+     *
+     */
+    void set_find_paired_permutations(bool do_find_paired_permutations);
 
     /**
      *
@@ -283,6 +292,13 @@ class pq_helper {
      *
      */
     bool cluster_operators_commute;
+
+    /**
+     *
+     * should we look for paired ov permutations that arise in ccsdt?
+     *
+     */
+    bool find_paired_permutations;
 
 };
 

--- a/pdaggerq/pq_string.cc
+++ b/pdaggerq/pq_string.cc
@@ -171,6 +171,65 @@ void pq_string::print() {
             printf(" ");
         }
     }
+    if ( paired_permutations_2.size() > 0 ) {
+        // should have an number of symbols divisible by 4
+        size_t n = paired_permutations_2.size() / 4;
+        int count = 0;
+        for (int i = 0; i < n; i++) {
+            printf("PP2(");
+            printf("%s",paired_permutations_2[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_2[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_2[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_2[count++].c_str());
+            printf(")");
+            printf(" ");
+        }
+    }
+    if ( paired_permutations_6.size() > 0 ) {
+        // should have an number of symbols divisible by 6
+        size_t n = paired_permutations_6.size() / 6;
+        int count = 0;
+        for (int i = 0; i < n; i++) {
+            printf("PP6(");
+            printf("%s",paired_permutations_6[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_6[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_6[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_6[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_6[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_6[count++].c_str());
+            printf(")");
+            printf(" ");
+        }
+    }
+    if ( paired_permutations_3.size() > 0 ) {
+        // should have an number of symbols divisible by 6
+        size_t n = paired_permutations_3.size() / 6;
+        int count = 0;
+        for (int i = 0; i < n; i++) {
+            printf("PP3(");
+            printf("%s",paired_permutations_3[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_3[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_3[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_3[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_3[count++].c_str());
+            printf(",");
+            printf("%s",paired_permutations_3[count++].c_str());
+            printf(")");
+            printf(" ");
+        }
+    }
 
     for (size_t i = 0; i < symbol.size(); i++) {
         printf("%s", symbol[i].c_str());
@@ -255,6 +314,68 @@ std::vector<std::string> pq_string::get_string_with_spin() {
             my_string.push_back(tmp);
         }
     }   
+
+    if ( paired_permutations_2.size() > 0 ) {
+        // should have a number of symbols divisible by 4
+        size_t n = paired_permutations_2.size() / 4;
+        size_t count = 0;
+        for (size_t i = 0; i < n; i++) {
+            tmp  = "PP2(";
+            tmp += paired_permutations_2[count++];
+            tmp += ",";
+            tmp += paired_permutations_2[count++];
+            tmp += ",";
+            tmp += paired_permutations_2[count++];
+            tmp += ",";
+            tmp += paired_permutations_2[count++];
+            tmp += ")";
+            my_string.push_back(tmp);
+        }
+    }
+
+    if ( paired_permutations_6.size() > 0 ) {
+        // should have a number of symbols divisible by 6
+        size_t n = paired_permutations_6.size() / 6;
+        size_t count = 0;
+        for (size_t i = 0; i < n; i++) {
+            tmp  = "PP6(";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ")";
+            my_string.push_back(tmp);
+        }
+    }
+
+    if ( paired_permutations_3.size() > 0 ) {
+        // should have a number of symbols divisible by 6
+        size_t n = paired_permutations_3.size() / 6;
+        size_t count = 0;
+        for (size_t i = 0; i < n; i++) {
+            tmp  = "PP3(";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ")";
+            my_string.push_back(tmp);
+        }
+    }
     
     for (size_t i = 0; i < symbol.size(); i++) {
         std::string tmp = symbol[i];
@@ -334,6 +455,68 @@ std::vector<std::string> pq_string::get_string() {
             tmp += permutations[count++];
             tmp += ",";
             tmp += permutations[count++];
+            tmp += ")";
+            my_string.push_back(tmp);
+        }
+    }
+
+    if ( paired_permutations_2.size() > 0 ) {
+        // should have a number of symbols divisible by 4
+        size_t n = paired_permutations_2.size() / 4;
+        size_t count = 0;
+        for (size_t i = 0; i < n; i++) {
+            tmp  = "PP2(";
+            tmp += paired_permutations_2[count++];
+            tmp += ",";
+            tmp += paired_permutations_2[count++];
+            tmp += ",";
+            tmp += paired_permutations_2[count++];
+            tmp += ",";
+            tmp += paired_permutations_2[count++];
+            tmp += ")";
+            my_string.push_back(tmp);
+        }
+    }
+
+    if ( paired_permutations_6.size() > 0 ) {
+        // should have a number of symbols divisible by 6
+        size_t n = paired_permutations_6.size() / 6;
+        size_t count = 0;
+        for (size_t i = 0; i < n; i++) {
+            tmp  = "PP6(";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ",";
+            tmp += paired_permutations_6[count++];
+            tmp += ")";
+            my_string.push_back(tmp);
+        }
+    }
+
+    if ( paired_permutations_3.size() > 0 ) {
+        // should have a number of symbols divisible by 6
+        size_t n = paired_permutations_3.size() / 6;
+        size_t count = 0;
+        for (size_t i = 0; i < n; i++) {
+            tmp  = "PP3(";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
+            tmp += ",";
+            tmp += paired_permutations_3[count++];
             tmp += ")";
             my_string.push_back(tmp);
         }
@@ -431,6 +614,21 @@ void pq_string::copy(void * copy_me, bool copy_daggers_and_symbols) {
     // permutations
     for (size_t i = 0; i < in->permutations.size(); i++) {
         permutations.push_back(in->permutations[i]);
+    }
+
+    // paired permutations (2)
+    for (size_t i = 0; i < in->paired_permutations_2.size(); i++) {
+        paired_permutations_2.push_back(in->paired_permutations_2[i]);
+    }
+
+    // paired permutations (3)
+    for (size_t i = 0; i < in->paired_permutations_3.size(); i++) {
+        paired_permutations_3.push_back(in->paired_permutations_3[i]);
+    }
+
+    // paired permutations (6)
+    for (size_t i = 0; i < in->paired_permutations_6.size(); i++) {
+        paired_permutations_6.push_back(in->paired_permutations_6[i]);
     }
 
     if ( copy_daggers_and_symbols ) {

--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -136,10 +136,31 @@ class pq_string {
 
     /**
      *
-     * a list of permutation operators
+     * a list of permutation operators: P(i,j) R(ijab) = R(ijab) - R(jiab)
      *
      */
     std::vector<std::string> permutations;
+
+    /**
+     *
+     * a list of permutation operators: PP6(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + R(ikj;acb) + R(jik;bac) + R(jki;bca) + R(kij;cab) + R(kji;cba)
+     *
+     */
+    std::vector<std::string> paired_permutations_6;
+
+    /**
+     *
+     * a list of permutation operators: PP3(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + (jik;bac) + R(kji;cba)
+     *
+     */
+    std::vector<std::string> paired_permutations_3;
+
+    /**
+     *
+     * a list of permutation operators: PP2(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + (jik;bac)
+     *
+     */
+    std::vector<std::string> paired_permutations_2;
 
     /**
      *

--- a/pdaggerq/pq_utils.cc
+++ b/pdaggerq/pq_utils.cc
@@ -455,6 +455,11 @@ void consolidate_permutations_non_summed(
     std::vector<std::string> labels) {
 
     for (size_t i = 0; i < ordered.size(); i++) {
+
+        // not sure if this logic works with existing permutation operators ... skip those for now
+        if ( ordered[i]->paired_permutations_2.size() > 0 ) continue;
+        if ( ordered[i]->paired_permutations_3.size() > 0 ) continue;
+        if ( ordered[i]->paired_permutations_6.size() > 0 ) continue;
         
         if ( ordered[i]->skip ) continue;
     
@@ -538,6 +543,793 @@ void consolidate_permutations_non_summed(
             }
 
             // otherwise, something has gone wrong in the previous consolidation step...
+        }
+    }
+}
+
+// look for paired permutations:
+// a) PP6(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + R(ikj;acb) + R(jik;bac) + R(jki;bca) + R(kij;cab) + R(kji;cba)
+// b) PP3(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + (jik;bac) + R(kji;cba)
+void consolidate_paired_permutations_non_summed(
+    std::vector<std::shared_ptr<pq_string> > &ordered,
+    std::vector<std::string> occ_labels,
+    std::vector<std::string> vir_labels) {
+
+    // look for 6-fold permutations
+    for (size_t i = 0; i < ordered.size(); i++) {
+
+        if ( ordered[i]->skip ) continue;
+
+        // not sure if this logic works with existing permutation operators ... skip those for now
+        if ( ordered[i]->permutations.size() > 0 ) continue;
+
+        std::vector<std::string> found_occ;
+        std::vector<std::string> found_vir;
+        std::vector<std::string> found_summed_occ;
+        std::vector<std::string> found_summed_vir;
+
+        // ok, what non-summed occupied labels do we have? 
+        for (size_t j = 0; j < occ_labels.size(); j++) {
+            int found = index_in_anywhere(ordered[i], occ_labels[j]);
+            if ( found == 1 ) {
+                found_occ.push_back(occ_labels[j]);
+            }
+        }
+
+        // ok, what non-summed virtual labels do we have? 
+        for (size_t j = 0; j < vir_labels.size(); j++) {
+            int found = index_in_anywhere(ordered[i], vir_labels[j]);
+            if ( found == 1 ) {
+                found_vir.push_back(vir_labels[j]);
+            }
+        }
+
+        // ok, what summed labels (occupied and virtual) do we have? 
+        for (size_t j = 0; j < occ_labels.size(); j++) {
+            int found = index_in_anywhere(ordered[i], occ_labels[j]);
+            if ( found == 2 ) {
+                found_summed_occ.push_back(occ_labels[j]);
+            }
+        }
+        for (size_t j = 0; j < vir_labels.size(); j++) {
+            int found = index_in_anywhere(ordered[i], vir_labels[j]);
+            if ( found == 2 ) {
+                found_summed_vir.push_back(vir_labels[j]);
+            }
+        }
+
+        // this function only works for swapping exactly three ov pairs
+        if ( found_occ.size() != 3 || found_vir.size() != 3 ) continue;
+
+        // ov pairs to swap
+        std::vector<std::vector<std::string>> pairs;
+        pairs.push_back({found_occ[0], found_vir[0]});
+        pairs.push_back({found_occ[1], found_vir[1]});
+        pairs.push_back({found_occ[2], found_vir[2]});
+
+        // which labels are involve in the permutation?
+        std::vector<size_t> my_permutations;
+
+        // loop over other strings
+        for (size_t j = i+1; j < ordered.size(); j++) {
+
+            if ( ordered[j]->skip ) continue;
+
+            // not sure if this logic works with existing permutation operators ... skip those for now
+            if ( ordered[j]->permutations.size() > 0 ) continue;
+
+            int n_permute;
+            bool strings_same = compare_strings(ordered[i],ordered[j],n_permute);
+
+            // try swapping three pairs of non-summed labels
+            bool found_paired_permutation = false;
+            for (size_t pair1 = 0; pair1 < pairs.size(); pair1++) {
+                std::string o1 = pairs[pair1][0];
+                std::string v1 = pairs[pair1][1];
+                for (size_t pair2 = pair1 + 1; pair2 < pairs.size(); pair2++) {
+                    std::string o2 = pairs[pair2][0];
+                    if ( o2 == o1 ) continue;
+                    std::string v2 = pairs[pair2][1];
+                    if ( v2 == v1 ) continue;
+                    for (size_t pair3 = pair2 + 1; pair3 < pairs.size(); pair3++) {
+                        std::string o3 = pairs[pair3][0];
+                        if ( o3 == o2 ) continue;
+                        if ( o3 == o1 ) continue;
+                        std::string v3 = pairs[pair3][1];
+                        if ( v3 == v2 ) continue;
+                        if ( v3 == v1 ) continue;
+
+                        bool paired_permutation = false;
+
+                        // for determining type P3 permutations
+                        bool is_permutation_type_0 = false;
+                        bool is_permutation_type_1 = false;
+
+                        for (size_t permutation_type = 0; permutation_type < 5; permutation_type++) {
+
+                            std::shared_ptr<pq_string> newguy (new pq_string(ordered[i]->vacuum));
+                            newguy->copy(ordered[i].get());
+
+                            if ( permutation_type == 0 ) {
+
+                                // 1 <-> 2
+                                swap_two_labels(newguy, o1, o2);
+                                swap_two_labels(newguy, v1, v2);
+
+                            }else if ( permutation_type == 1 ) {
+
+                                // 1 <-> 3
+                                swap_two_labels(newguy, o1, o3);
+                                swap_two_labels(newguy, v1, v3);
+
+                            }else if ( permutation_type == 2 ) {
+
+                                // 2 <-> 3
+                                swap_two_labels(newguy, o2, o3);
+                                swap_two_labels(newguy, v2, v3);
+
+                            }else if ( permutation_type == 3 ) {
+
+                                // 1 <-> 2
+                                swap_two_labels(newguy, o1, o2);
+                                swap_two_labels(newguy, v1, v2);
+
+                                // 1 <-> 3
+                                swap_two_labels(newguy, o1, o3);
+                                swap_two_labels(newguy, v1, v3);
+
+                            }else if ( permutation_type == 4 ) {
+
+                                // 1 <-> 2
+                                swap_two_labels(newguy, o1, o2);
+                                swap_two_labels(newguy, v1, v2);
+
+                                // 2 <-> 3
+                                swap_two_labels(newguy, o2, o3);
+                                swap_two_labels(newguy, v2, v3);
+
+                            }
+                            newguy->sort_labels();
+
+                            strings_same = compare_strings(ordered[j], newguy, n_permute);
+
+                            if ( strings_same ) {
+                                paired_permutation = true;
+                                break;
+                            }
+                        }
+
+                        if ( !paired_permutation ) break;
+
+                        double factor_i = ordered[i]->factor * ordered[i]->sign;
+                        double factor_j = ordered[j]->factor * ordered[j]->sign;
+
+                        double combined_factor = factor_i - factor_j * pow(-1.0,n_permute);
+
+                        // if factors are identical, then this is a paired permutation
+                        if ( fabs(combined_factor) < 1e-12 ) {
+                            //ordered[j]->print();
+
+                            // keep track of which term this is
+                            my_permutations.push_back(j);
+
+                            found_paired_permutation = true;
+                        }
+                        if ( found_paired_permutation ) break;
+                    }
+                    if ( found_paired_permutation ) break;
+                }
+                if ( found_paired_permutation ) break;
+            }
+
+            // try swapping three pairs of non-summed labels plus one summed occupied label
+            if ( !found_paired_permutation) {
+
+                // try swapping summed occupied labels
+                for (size_t id1 = 0; id1 < found_summed_occ.size(); id1++) {
+                    for (size_t id2 = id1 + 1; id2 < found_summed_occ.size(); id2++) {
+
+                        // try swapping three pairs of non-summed labels
+                        bool found_paired_permutation = false;
+                        for (size_t pair1 = 0; pair1 < pairs.size(); pair1++) {
+                            std::string o1 = pairs[pair1][0];
+                            std::string v1 = pairs[pair1][1];
+                            for (size_t pair2 = pair1 + 1; pair2 < pairs.size(); pair2++) {
+                                std::string o2 = pairs[pair2][0];
+                                if ( o2 == o1 ) continue;
+                                std::string v2 = pairs[pair2][1];
+                                if ( v2 == v1 ) continue;
+                                for (size_t pair3 = pair2 + 1; pair3 < pairs.size(); pair3++) {
+                                    std::string o3 = pairs[pair3][0];
+                                    if ( o3 == o2 ) continue;
+                                    if ( o3 == o1 ) continue;
+                                    std::string v3 = pairs[pair3][1];
+                                    if ( v3 == v2 ) continue;
+                                    if ( v3 == v1 ) continue;
+
+                                    bool paired_permutation = false;
+
+                                    for (size_t permutation_type = 0; permutation_type < 5; permutation_type++) {
+
+                                        std::shared_ptr<pq_string> newguy (new pq_string(ordered[i]->vacuum));
+                                        newguy->copy(ordered[i].get());
+                                        swap_two_labels(newguy, found_summed_occ[id1], found_summed_occ[id2]);
+
+                                        if ( permutation_type == 0 ) {
+
+                                            // 1 <-> 2
+                                            swap_two_labels(newguy, o1, o2);
+                                            swap_two_labels(newguy, v1, v2);
+
+                                        }else if ( permutation_type == 1 ) {
+
+                                            // 1 <-> 3
+                                            swap_two_labels(newguy, o1, o3);
+                                            swap_two_labels(newguy, v1, v3);
+
+                                        }else if ( permutation_type == 2 ) {
+
+                                            // 2 <-> 3
+                                            swap_two_labels(newguy, o2, o3);
+                                            swap_two_labels(newguy, v2, v3);
+
+                                        }else if ( permutation_type == 3 ) {
+
+                                            // 1 <-> 2
+                                            swap_two_labels(newguy, o1, o2);
+                                            swap_two_labels(newguy, v1, v2);
+
+                                            // 1 <-> 3
+                                            swap_two_labels(newguy, o1, o3);
+                                            swap_two_labels(newguy, v1, v3);
+
+                                        }else if ( permutation_type == 4 ) {
+
+                                            // 1 <-> 2
+                                            swap_two_labels(newguy, o1, o2);
+                                            swap_two_labels(newguy, v1, v2);
+
+                                            // 2 <-> 3
+                                            swap_two_labels(newguy, o2, o3);
+                                            swap_two_labels(newguy, v2, v3);
+
+                                        }
+                                        newguy->sort_labels();
+
+                                        strings_same = compare_strings(ordered[j], newguy, n_permute);
+
+                                        if ( strings_same ) {
+                                            paired_permutation = true;
+                                            break;
+                                        }
+                                    }
+
+                                    if ( !paired_permutation ) break;
+
+                                    double factor_i = ordered[i]->factor * ordered[i]->sign;
+                                    double factor_j = ordered[j]->factor * ordered[j]->sign;
+
+                                    double combined_factor = factor_i - factor_j * pow(-1.0,n_permute);
+
+                                    // if factors are identical, then this is a paired permutation
+                                    if ( fabs(combined_factor) < 1e-12 ) {
+                                        //ordered[j]->print();
+
+                                        // keep track of which term this is
+                                        my_permutations.push_back(j);
+
+                                        found_paired_permutation = true;
+                                    }
+                                    if ( found_paired_permutation ) break;
+                                }
+                                if ( found_paired_permutation ) break;
+                            }
+                            if ( found_paired_permutation ) break;
+                        }
+                    }
+                }
+            }
+
+            // try swapping three pairs of non-summed labels plus one summed virtual label
+            if ( !found_paired_permutation) {
+
+                // try swapping summed virtual labels
+                for (size_t id1 = 0; id1 < found_summed_vir.size(); id1++) {
+                    for (size_t id2 = id1 + 1; id2 < found_summed_vir.size(); id2++) {
+
+                        // try swapping three pairs of non-summed labels
+                        bool found_paired_permutation = false;
+                        for (size_t pair1 = 0; pair1 < pairs.size(); pair1++) {
+                            std::string o1 = pairs[pair1][0];
+                            std::string v1 = pairs[pair1][1];
+                            for (size_t pair2 = pair1 + 1; pair2 < pairs.size(); pair2++) {
+                                std::string o2 = pairs[pair2][0];
+                                if ( o2 == o1 ) continue;
+                                std::string v2 = pairs[pair2][1];
+                                if ( v2 == v1 ) continue;
+                                for (size_t pair3 = pair2 + 1; pair3 < pairs.size(); pair3++) {
+                                    std::string o3 = pairs[pair3][0];
+                                    if ( o3 == o2 ) continue;
+                                    if ( o3 == o1 ) continue;
+                                    std::string v3 = pairs[pair3][1];
+                                    if ( v3 == v2 ) continue;
+                                    if ( v3 == v1 ) continue;
+
+                                    bool paired_permutation = false;
+
+                                    for (size_t permutation_type = 0; permutation_type < 5; permutation_type++) {
+
+                                        std::shared_ptr<pq_string> newguy (new pq_string(ordered[i]->vacuum));
+                                        newguy->copy(ordered[i].get());
+                                        swap_two_labels(newguy, found_summed_vir[id1], found_summed_vir[id2]);
+
+                                        if ( permutation_type == 0 ) {
+
+                                            // 1 <-> 2
+                                            swap_two_labels(newguy, o1, o2);
+                                            swap_two_labels(newguy, v1, v2);
+
+                                        }else if ( permutation_type == 1 ) {
+
+                                            // 1 <-> 3
+                                            swap_two_labels(newguy, o1, o3);
+                                            swap_two_labels(newguy, v1, v3);
+
+                                        }else if ( permutation_type == 2 ) {
+
+                                            // 2 <-> 3
+                                            swap_two_labels(newguy, o2, o3);
+                                            swap_two_labels(newguy, v2, v3);
+
+                                        }else if ( permutation_type == 3 ) {
+
+                                            // 1 <-> 2
+                                            swap_two_labels(newguy, o1, o2);
+                                            swap_two_labels(newguy, v1, v2);
+
+                                            // 1 <-> 3
+                                            swap_two_labels(newguy, o1, o3);
+                                            swap_two_labels(newguy, v1, v3);
+
+                                        }else if ( permutation_type == 4 ) {
+
+                                            // 1 <-> 2
+                                            swap_two_labels(newguy, o1, o2);
+                                            swap_two_labels(newguy, v1, v2);
+
+                                            // 2 <-> 3
+                                            swap_two_labels(newguy, o2, o3);
+                                            swap_two_labels(newguy, v2, v3);
+
+                                        }
+                                        newguy->sort_labels();
+
+                                        strings_same = compare_strings(ordered[j], newguy, n_permute);
+
+                                        if ( strings_same ) {
+                                            paired_permutation = true;
+                                            break;
+                                        }
+                                    }
+
+                                    if ( !paired_permutation ) break;
+
+                                    double factor_i = ordered[i]->factor * ordered[i]->sign;
+                                    double factor_j = ordered[j]->factor * ordered[j]->sign;
+
+                                    double combined_factor = factor_i - factor_j * pow(-1.0,n_permute);
+
+                                    // if factors are identical, then this is a paired permutation
+                                    if ( fabs(combined_factor) < 1e-12 ) {
+                                        //ordered[j]->print();
+
+                                        // keep track of which term this is
+                                        my_permutations.push_back(j);
+
+                                        found_paired_permutation = true;
+                                    }
+                                    if ( found_paired_permutation ) break;
+                                }
+                                if ( found_paired_permutation ) break;
+                            }
+                            if ( found_paired_permutation ) break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if ( my_permutations.size() > 0 ) {
+            if ( my_permutations.size() == 5 ) {
+                for (size_t j = 0; j < my_permutations.size(); j++ ) {
+                    ordered[my_permutations[j]]->skip = true;
+                }
+                ordered[i]->paired_permutations_6.push_back(found_occ[0]);
+                ordered[i]->paired_permutations_6.push_back(found_vir[0]);
+                ordered[i]->paired_permutations_6.push_back(found_occ[1]);
+                ordered[i]->paired_permutations_6.push_back(found_vir[1]);
+                ordered[i]->paired_permutations_6.push_back(found_occ[2]);
+                ordered[i]->paired_permutations_6.push_back(found_vir[2]);
+            }
+        }
+    }
+
+    // now, look for 3-fold permutations
+    for (size_t i = 0; i < ordered.size(); i++) {
+
+        if ( ordered[i]->skip ) continue;
+
+        // not sure if this logic works with existing permutation operators ... skip those for now
+        if ( ordered[i]->permutations.size() > 0 ) continue;
+
+        std::vector<std::string> found_occ;
+        std::vector<std::string> found_vir;
+        std::vector<std::string> found_summed_occ;
+        std::vector<std::string> found_summed_vir;
+
+        // ok, what non-summed occupied labels do we have? 
+        for (size_t j = 0; j < occ_labels.size(); j++) {
+            int found = index_in_anywhere(ordered[i], occ_labels[j]);
+            if ( found == 1 ) {
+                found_occ.push_back(occ_labels[j]);
+            }
+        }
+
+        // ok, what non-summed virtual labels do we have? 
+        for (size_t j = 0; j < vir_labels.size(); j++) {
+            int found = index_in_anywhere(ordered[i], vir_labels[j]);
+            if ( found == 1 ) {
+                found_vir.push_back(vir_labels[j]);
+            }
+        }
+
+        // ok, what summed labels (occupied and virtual) do we have? 
+        for (size_t j = 0; j < occ_labels.size(); j++) {
+            int found = index_in_anywhere(ordered[i], occ_labels[j]);
+            if ( found == 2 ) {
+                found_summed_occ.push_back(occ_labels[j]);
+            }
+        }
+        for (size_t j = 0; j < vir_labels.size(); j++) {
+            int found = index_in_anywhere(ordered[i], vir_labels[j]);
+            if ( found == 2 ) {
+                found_summed_vir.push_back(vir_labels[j]);
+            }
+        }
+
+        // this function only works for swapping exactly three ov pairs
+        if ( found_occ.size() != 3 || found_vir.size() != 3 ) continue;
+
+        // ov pairs to swap
+        std::vector<std::vector<std::string>> pairs;
+        pairs.push_back({found_occ[0], found_vir[0]});
+        pairs.push_back({found_occ[1], found_vir[1]});
+        pairs.push_back({found_occ[2], found_vir[2]});
+
+        // which labels are involve in the permutation?
+        std::vector<size_t> my_permutations;
+
+        // which pairs are swapped ( 12, 13, 23 ) ... this affects how we label
+        std::vector<bool> permutation_types = { false, false, false };
+
+        // loop over other strings
+        for (size_t j = i+1; j < ordered.size(); j++) {
+
+            if ( ordered[j]->skip ) continue;
+
+            // not sure if this logic works with existing permutation operators ... skip those for now
+            if ( ordered[j]->permutations.size() > 0 ) continue;
+
+            int n_permute;
+            bool strings_same = compare_strings(ordered[i],ordered[j],n_permute);
+
+            // try swapping three pairs of non-summed labels
+            bool found_paired_permutation = false;
+
+            for (size_t pair1 = 0; pair1 < pairs.size(); pair1++) {
+                std::string o1 = pairs[pair1][0];
+                std::string v1 = pairs[pair1][1];
+                for (size_t pair2 = pair1 + 1; pair2 < pairs.size(); pair2++) {
+                    std::string o2 = pairs[pair2][0];
+                    if ( o2 == o1 ) continue;
+                    std::string v2 = pairs[pair2][1];
+                    if ( v2 == v1 ) continue;
+                    for (size_t pair3 = pair2 + 1; pair3 < pairs.size(); pair3++) {
+                        std::string o3 = pairs[pair3][0];
+                        if ( o3 == o2 ) continue;
+                        if ( o3 == o1 ) continue;
+                        std::string v3 = pairs[pair3][1];
+                        if ( v3 == v2 ) continue;
+                        if ( v3 == v1 ) continue;
+
+                        bool paired_permutation = false;
+
+                        // for determining type P3 permutations
+                        bool is_permutation_type_0 = false;
+                        bool is_permutation_type_1 = false;
+
+                        int found_permutation_type = -1;
+                        for (size_t permutation_type = 0; permutation_type < 3; permutation_type++) {
+
+                            std::shared_ptr<pq_string> newguy (new pq_string(ordered[i]->vacuum));
+                            newguy->copy(ordered[i].get());
+
+                            if ( permutation_type == 0 ) {
+
+                                // 1 <-> 2
+                                swap_two_labels(newguy, o1, o2);
+                                swap_two_labels(newguy, v1, v2);
+
+                            }else if ( permutation_type == 1 ) {
+
+                                // 1 <-> 3
+                                swap_two_labels(newguy, o1, o3);
+                                swap_two_labels(newguy, v1, v3);
+
+                            }else if ( permutation_type == 2 ) {
+
+                                // 2 <-> 3
+                                swap_two_labels(newguy, o2, o3);
+                                swap_two_labels(newguy, v2, v3);
+
+                            }
+                            newguy->sort_labels();
+
+                            strings_same = compare_strings(ordered[j], newguy, n_permute);
+
+                            if ( strings_same ) {
+                                paired_permutation = true;
+                                found_permutation_type = permutation_type;
+                                break;
+                            }
+                        }
+
+                        if ( !paired_permutation ) break;
+
+                        double factor_i = ordered[i]->factor * ordered[i]->sign;
+                        double factor_j = ordered[j]->factor * ordered[j]->sign;
+
+                        double combined_factor = factor_i - factor_j * pow(-1.0,n_permute);
+
+                        // if factors are identical, then this is a paired permutation
+                        if ( fabs(combined_factor) < 1e-12 ) {
+                            //ordered[j]->print();
+
+                            // keep track of which term this is
+                            my_permutations.push_back(j);
+
+                            found_paired_permutation = true;
+
+                            // keep track of which labels were swapped
+                            permutation_types[found_permutation_type] = true;
+                        }
+                        if ( found_paired_permutation ) break;
+                    }
+                    if ( found_paired_permutation ) break;
+                }
+                if ( found_paired_permutation ) break;
+            }
+
+            // try swapping three pairs of non-summed labels plus one summed occupied label
+            if ( !found_paired_permutation) {
+
+                // try swapping summed occupied labels
+                for (size_t id1 = 0; id1 < found_summed_occ.size(); id1++) {
+                    for (size_t id2 = id1 + 1; id2 < found_summed_occ.size(); id2++) {
+
+                        // try swapping three pairs of non-summed labels
+                        bool found_paired_permutation = false;
+                        for (size_t pair1 = 0; pair1 < pairs.size(); pair1++) {
+                            std::string o1 = pairs[pair1][0];
+                            std::string v1 = pairs[pair1][1];
+                            for (size_t pair2 = pair1 + 1; pair2 < pairs.size(); pair2++) {
+                                std::string o2 = pairs[pair2][0];
+                                if ( o2 == o1 ) continue;
+                                std::string v2 = pairs[pair2][1];
+                                if ( v2 == v1 ) continue;
+                                for (size_t pair3 = pair2 + 1; pair3 < pairs.size(); pair3++) {
+                                    std::string o3 = pairs[pair3][0];
+                                    if ( o3 == o2 ) continue;
+                                    if ( o3 == o1 ) continue;
+                                    std::string v3 = pairs[pair3][1];
+                                    if ( v3 == v2 ) continue;
+                                    if ( v3 == v1 ) continue;
+
+                                    bool paired_permutation = false;
+
+                                    int found_permutation_type = -1;
+                                    for (size_t permutation_type = 0; permutation_type < 3; permutation_type++) {
+
+                                        std::shared_ptr<pq_string> newguy (new pq_string(ordered[i]->vacuum));
+                                        newguy->copy(ordered[i].get());
+                                        swap_two_labels(newguy, found_summed_occ[id1], found_summed_occ[id2]);
+
+                                        if ( permutation_type == 0 ) {
+
+                                            // 1 <-> 2
+                                            swap_two_labels(newguy, o1, o2);
+                                            swap_two_labels(newguy, v1, v2);
+
+                                        }else if ( permutation_type == 1 ) {
+
+                                            // 1 <-> 3
+                                            swap_two_labels(newguy, o1, o3);
+                                            swap_two_labels(newguy, v1, v3);
+
+                                        }else if ( permutation_type == 2 ) {
+
+                                            // 2 <-> 3
+                                            swap_two_labels(newguy, o2, o3);
+                                            swap_two_labels(newguy, v2, v3);
+
+                                        }
+                                        newguy->sort_labels();
+
+                                        strings_same = compare_strings(ordered[j], newguy, n_permute);
+
+                                        if ( strings_same ) {
+                                            paired_permutation = true;
+                                            found_permutation_type = permutation_type;
+                                            break;
+                                        }
+                                    }
+
+                                    if ( !paired_permutation ) break;
+
+                                    double factor_i = ordered[i]->factor * ordered[i]->sign;
+                                    double factor_j = ordered[j]->factor * ordered[j]->sign;
+
+                                    double combined_factor = factor_i - factor_j * pow(-1.0,n_permute);
+
+                                    // if factors are identical, then this is a paired permutation
+                                    if ( fabs(combined_factor) < 1e-12 ) {
+                                        //ordered[j]->print();
+
+                                        // keep track of which term this is
+                                        my_permutations.push_back(j);
+
+                                        found_paired_permutation = true;
+
+                                        // keep track of which labels were swapped
+                                        permutation_types[found_permutation_type] = true;
+                                    }
+                                    if ( found_paired_permutation ) break;
+                                }
+                                if ( found_paired_permutation ) break;
+                            }
+                            if ( found_paired_permutation ) break;
+                        }
+                    }
+                }
+            }
+
+            // try swapping three pairs of non-summed labels plus one summed virtual label
+            if ( !found_paired_permutation) {
+
+                // try swapping summed virtual labels
+                for (size_t id1 = 0; id1 < found_summed_vir.size(); id1++) {
+                    for (size_t id2 = id1 + 1; id2 < found_summed_vir.size(); id2++) {
+
+                        // try swapping three pairs of non-summed labels
+                        bool found_paired_permutation = false;
+                        for (size_t pair1 = 0; pair1 < pairs.size(); pair1++) {
+                            std::string o1 = pairs[pair1][0];
+                            std::string v1 = pairs[pair1][1];
+                            for (size_t pair2 = pair1 + 1; pair2 < pairs.size(); pair2++) {
+                                std::string o2 = pairs[pair2][0];
+                                if ( o2 == o1 ) continue;
+                                std::string v2 = pairs[pair2][1];
+                                if ( v2 == v1 ) continue;
+                                for (size_t pair3 = pair2 + 1; pair3 < pairs.size(); pair3++) {
+                                    std::string o3 = pairs[pair3][0];
+                                    if ( o3 == o2 ) continue;
+                                    if ( o3 == o1 ) continue;
+                                    std::string v3 = pairs[pair3][1];
+                                    if ( v3 == v2 ) continue;
+                                    if ( v3 == v1 ) continue;
+
+                                    bool paired_permutation = false;
+
+                                    int found_permutation_type = -1;
+                                    for (size_t permutation_type = 0; permutation_type < 3; permutation_type++) {
+
+                                        std::shared_ptr<pq_string> newguy (new pq_string(ordered[i]->vacuum));
+                                        newguy->copy(ordered[i].get());
+                                        swap_two_labels(newguy, found_summed_vir[id1], found_summed_vir[id2]);
+
+                                        if ( permutation_type == 0 ) {
+
+                                            // 1 <-> 2
+                                            swap_two_labels(newguy, o1, o2);
+                                            swap_two_labels(newguy, v1, v2);
+
+                                        }else if ( permutation_type == 1 ) {
+
+                                            // 1 <-> 3
+                                            swap_two_labels(newguy, o1, o3);
+                                            swap_two_labels(newguy, v1, v3);
+
+                                        }else if ( permutation_type == 2 ) {
+
+                                            // 2 <-> 3
+                                            swap_two_labels(newguy, o2, o3);
+                                            swap_two_labels(newguy, v2, v3);
+
+                                        }
+                                        newguy->sort_labels();
+
+                                        strings_same = compare_strings(ordered[j], newguy, n_permute);
+
+                                        if ( strings_same ) {
+                                            paired_permutation = true;
+                                            found_permutation_type = permutation_type;
+                                            break;
+                                        }
+                                    }
+
+                                    if ( !paired_permutation ) break;
+
+                                    double factor_i = ordered[i]->factor * ordered[i]->sign;
+                                    double factor_j = ordered[j]->factor * ordered[j]->sign;
+
+                                    double combined_factor = factor_i - factor_j * pow(-1.0,n_permute);
+
+                                    // if factors are identical, then this is a paired permutation
+                                    if ( fabs(combined_factor) < 1e-12 ) {
+                                        //ordered[j]->print();
+
+                                        // keep track of which term this is
+                                        my_permutations.push_back(j);
+
+                                        found_paired_permutation = true;
+
+                                        // keep track of which labels were swapped
+                                        permutation_types[found_permutation_type] = true;
+                                    }
+                                    if ( found_paired_permutation ) break;
+                                }
+                                if ( found_paired_permutation ) break;
+                            }
+                            if ( found_paired_permutation ) break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if ( my_permutations.size() == 2 ) {
+            for (size_t j = 0; j < my_permutations.size(); j++ ) {
+                ordered[my_permutations[j]]->skip = true;
+            }
+
+            if ( permutation_types[0] && permutation_types[1] && permutation_types[2] ) {
+                printf("\n");
+                printf("    something has gone terribly wrong in consolidate_paired_permutations_non_summed()\n");
+                printf("\n");
+                exit(1);
+            }
+            if ( permutation_types[0] && permutation_types[1] ) {
+                ordered[i]->paired_permutations_3.push_back(found_occ[0]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[0]);
+                ordered[i]->paired_permutations_3.push_back(found_occ[1]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[1]);
+                ordered[i]->paired_permutations_3.push_back(found_occ[2]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[2]);
+            }else if ( permutation_types[0] && permutation_types[2] ) {
+                ordered[i]->paired_permutations_3.push_back(found_occ[1]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[1]);
+                ordered[i]->paired_permutations_3.push_back(found_occ[0]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[0]);
+                ordered[i]->paired_permutations_3.push_back(found_occ[2]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[2]);
+            }else if ( permutation_types[1] && permutation_types[2] ) {
+                ordered[i]->paired_permutations_3.push_back(found_occ[2]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[2]);
+                ordered[i]->paired_permutations_3.push_back(found_occ[0]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[0]);
+                ordered[i]->paired_permutations_3.push_back(found_occ[1]);
+                ordered[i]->paired_permutations_3.push_back(found_vir[1]);
+            }
         }
     }
 }
@@ -660,6 +1452,11 @@ void cleanup(std::vector<std::shared_ptr<pq_string> > &ordered) {
     // probably only relevant for vacuum = fermi
     if ( ordered.size() == 0 ) return;
     if ( ordered[0]->vacuum != "FERMI" ) return;
+
+    // look for paired permutations of non-summed labels:
+    // a) PP6(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + R(ikj;acb) + R(jik;bac) + R(jki;bca) + R(kij;cab) + R(kji;cba)
+    // b) PP3(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + (jik;bac) + R(kji;cba)
+    consolidate_paired_permutations_non_summed(ordered, occ_labels, vir_labels);
 
     consolidate_permutations_non_summed(ordered, occ_labels);
     consolidate_permutations_non_summed(ordered, vir_labels);
@@ -1326,9 +2123,9 @@ void spin_blocking(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq
     std::vector< std::shared_ptr<pq_string> > tmp;
     tmp.push_back(newguy);
 
+    // but first expand single permutations where spins don't match 
     for (size_t i = 0; i < tmp.size(); i++) {
 
-        // but first expand permutations where spins don't match 
         size_t n = tmp[i]->permutations.size() / 2;
 
         for (size_t j = 0; j < n; j++) {
@@ -1348,11 +2145,11 @@ void spin_blocking(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq
             if ( spin1 != spin2 ) {
 
                 // first guy is just a copy
-                std::shared_ptr<pq_string> newguy1 (new pq_string(in->vacuum));
+                std::shared_ptr<pq_string> newguy1 (new pq_string(tmp[i]->vacuum));
                 newguy1->copy(tmp[i].get());
 
                 // second guy is a copy with permuted labels and change in sign
-                std::shared_ptr<pq_string> newguy2 (new pq_string(in->vacuum));
+                std::shared_ptr<pq_string> newguy2 (new pq_string(tmp[i]->vacuum));
                 newguy2->copy(tmp[i].get());
                 swap_two_labels(newguy2, idx1, idx2);
                 newguy2->sign *= -1;
@@ -1379,6 +2176,529 @@ void spin_blocking(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq
                 tmp[i]->skip = true;
                 tmp.push_back(newguy1);
                 tmp.push_back(newguy2);
+
+                // break loop over permutations because this above logic only works on one permutation at a time
+                break;
+            }
+        }
+    }
+
+    // now expand paired permutations (3) where spins don't match 
+    for (size_t i = 0; i < tmp.size(); i++) {
+        size_t n = tmp[i]->paired_permutations_3.size() / 6;
+
+        for (size_t j = 0; j < n; j++) {
+
+            std::string o1 = tmp[i]->paired_permutations_3[6*j];
+            std::string v1 = tmp[i]->paired_permutations_3[6*j+1];
+            std::string o2 = tmp[i]->paired_permutations_3[6*j+2];
+            std::string v2 = tmp[i]->paired_permutations_3[6*j+3];
+            std::string o3 = tmp[i]->paired_permutations_3[6*j+4];
+            std::string v3 = tmp[i]->paired_permutations_3[6*j+5];
+
+            // spin 1
+            std::string spin1 = "";
+            spin1 = tmp[i]->non_summed_spin_labels[o1];
+            if ( spin1 != tmp[i]->non_summed_spin_labels[v1] ) {
+                printf("\n");
+                printf("    error: spin label mismatch between occupied and virtual orbitals (1)\n");
+                printf("\n");
+                exit(1);
+            }
+
+            // spin 2
+            std::string spin2 = "";
+            spin2 = tmp[i]->non_summed_spin_labels[o2];
+            if ( spin2 != tmp[i]->non_summed_spin_labels[v2] ) {
+                printf("\n");
+                printf("    error: spin label mismatch between occupied and virtual orbitals (2)\n");
+                printf("\n");
+                exit(1);
+            }
+
+            // spin 3
+            std::string spin3 = "";
+            spin3 = tmp[i]->non_summed_spin_labels[o3];
+            if ( spin3 != tmp[i]->non_summed_spin_labels[v3] ) {
+                printf("\n");
+                printf("    error: spin label mismatch between occupied and virtual orbitals (3)\n");
+                printf("\n");
+                exit(1);
+            }
+
+            // if spins are not the same, then the permutation needs to be expanded explicitly and allowed spins redetermined
+
+            // aab or bba -> PP2[ab](abc) + cba
+            if ( spin1 == spin2 && spin1 != spin3 ) {
+
+                // first guy is just a copy plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy1 (new pq_string(tmp[i]->vacuum));
+                newguy1->copy(tmp[i].get());
+
+                // adjust permutations. no more PP3, but we have PP2
+                newguy1->paired_permutations_3.clear();
+                newguy1->paired_permutations_2.push_back(o1);
+                newguy1->paired_permutations_2.push_back(v1);
+                newguy1->paired_permutations_2.push_back(o2);
+                newguy1->paired_permutations_2.push_back(v2);
+
+                // second guy is a copy with permuted pair labels and no change in sign
+                std::shared_ptr<pq_string> newguy2 (new pq_string(tmp[i]->vacuum));
+                newguy2->copy(tmp[i].get());
+                swap_two_labels(newguy2, o1, o3);
+                swap_two_labels(newguy2, v1, v3);
+
+                // reset non-summed spins for this guy
+                newguy2->reset_spin_labels();
+
+                // no more PP3
+                newguy2->paired_permutations_3.clear();
+
+                for (size_t k = 0; k < n; k++) {
+
+                    // skip jth permutation, which is the one we expanded
+                    if ( j == k ) continue;
+
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+1]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+2]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+3]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+4]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+5]);
+
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+1]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+2]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+3]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+4]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+5]);
+
+                }
+
+                tmp[i]->skip = true;
+                tmp.push_back(newguy1);
+                tmp.push_back(newguy2);
+
+                // break loop over permutations because this above logic only works on one permutation at a time
+                break;
+            }
+            // abb or baa -> abc + bac + cba
+            else if ( spin1 != spin2 && spin2 == spin3 ) {
+
+                // first guy is just a copy 
+                std::shared_ptr<pq_string> newguy1 (new pq_string(tmp[i]->vacuum));
+                newguy1->copy(tmp[i].get());
+
+                // adjust permutations. no more PP3.
+                newguy1->paired_permutations_3.clear();
+
+                // second guy is a copy with permuted pair labels and no change in sign
+                std::shared_ptr<pq_string> newguy2 (new pq_string(tmp[i]->vacuum));
+                newguy2->copy(tmp[i].get());
+                swap_two_labels(newguy2, o1, o2);
+                swap_two_labels(newguy2, v1, v2);
+
+                // reset non-summed spins for this guy
+                newguy2->reset_spin_labels();
+
+                // no more PP3
+                newguy2->paired_permutations_3.clear();
+
+                // third guy is a copy with permuted pair labels and no change in sign
+                std::shared_ptr<pq_string> newguy3 (new pq_string(tmp[i]->vacuum));
+                newguy3->copy(tmp[i].get());
+                swap_two_labels(newguy3, o1, o3);
+                swap_two_labels(newguy3, v1, v3);
+
+                // reset non-summed spins for this guy
+                newguy3->reset_spin_labels();
+
+                // no more PP3
+                newguy3->paired_permutations_3.clear();
+
+                for (size_t k = 0; k < n; k++) {
+
+                    // skip jth permutation, which is the one we expanded
+                    if ( j == k ) continue;
+
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+1]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+2]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+3]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+4]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+5]);
+
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+1]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+2]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+3]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+4]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+5]);
+
+                    newguy3->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k]);
+                    newguy3->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+1]);
+                    newguy3->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+2]);
+                    newguy3->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+3]);
+                    newguy3->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+4]);
+                    newguy3->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+5]);
+
+                }
+
+                tmp[i]->skip = true;
+                tmp.push_back(newguy1);
+                tmp.push_back(newguy2);
+                tmp.push_back(newguy3);
+
+                // break loop over permutations because this above logic only works on one permutation at a time
+                break;
+            }
+            // aba or bab -> PP2[ac](abc) + bac
+            else if ( spin1 != spin2 && spin1 == spin3 ) {
+
+                // first guy is just a copy plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy1 (new pq_string(tmp[i]->vacuum));
+                newguy1->copy(tmp[i].get());
+
+                // adjust permutations. no more PP3, but we have PP2
+                newguy1->paired_permutations_3.clear();
+                newguy1->paired_permutations_2.push_back(o1);
+                newguy1->paired_permutations_2.push_back(v1);
+                newguy1->paired_permutations_2.push_back(o3);
+                newguy1->paired_permutations_2.push_back(v3);
+
+                // second guy is a copy with permuted pair labels and no change in sign
+                std::shared_ptr<pq_string> newguy2 (new pq_string(tmp[i]->vacuum));
+                newguy2->copy(tmp[i].get());
+                swap_two_labels(newguy2, o1, o2);
+                swap_two_labels(newguy2, v1, v2);
+
+                // reset non-summed spins for this guy
+                newguy2->reset_spin_labels();
+
+                // no more PP3
+                newguy2->paired_permutations_3.clear();
+
+                for (size_t k = 0; k < n; k++) {
+
+                    // skip jth permutation, which is the one we expanded
+                    if ( j == k ) continue;
+
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+1]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+2]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+3]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+4]);
+                    newguy1->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+5]);
+
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+1]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+2]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+3]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+4]);
+                    newguy2->paired_permutations_3.push_back(tmp[i]->paired_permutations_3[6*k+5]);
+
+                }
+
+                tmp[i]->skip = true;
+                tmp.push_back(newguy1);
+                tmp.push_back(newguy2);
+
+                // break loop over permutations because this above logic only works on one permutation at a time
+                break;
+            }
+        }
+    }
+
+    // now expand paired permutations (6) where spins don't match 
+    for (size_t i = 0; i < tmp.size(); i++) {
+        size_t n = tmp[i]->paired_permutations_6.size() / 6;
+
+        for (size_t j = 0; j < n; j++) {
+
+            std::string o1 = tmp[i]->paired_permutations_6[6*j];
+            std::string v1 = tmp[i]->paired_permutations_6[6*j+1];
+            std::string o2 = tmp[i]->paired_permutations_6[6*j+2];
+            std::string v2 = tmp[i]->paired_permutations_6[6*j+3];
+            std::string o3 = tmp[i]->paired_permutations_6[6*j+4];
+            std::string v3 = tmp[i]->paired_permutations_6[6*j+5];
+
+            // spin 1
+            std::string spin1 = "";
+            spin1 = tmp[i]->non_summed_spin_labels[o1];
+            if ( spin1 != tmp[i]->non_summed_spin_labels[v1] ) {
+                printf("\n");
+                printf("    error: spin label mismatch between occupied and virtual orbitals (1)\n");
+                printf("\n");
+                exit(1);
+            }
+
+            // spin 2
+            std::string spin2 = "";
+            spin2 = tmp[i]->non_summed_spin_labels[o2];
+            if ( spin2 != tmp[i]->non_summed_spin_labels[v2] ) {
+                printf("\n");
+                printf("    error: spin label mismatch between occupied and virtual orbitals (2)\n");
+                printf("\n");
+                exit(1);
+            }
+
+            // spin 3
+            std::string spin3 = "";
+            spin3 = tmp[i]->non_summed_spin_labels[o3];
+            if ( spin3 != tmp[i]->non_summed_spin_labels[v3] ) {
+                printf("\n");
+                printf("    error: spin label mismatch between occupied and virtual orbitals (3)\n");
+                printf("\n");
+                exit(1);
+            }
+
+            // if spins are not the same, then the permutation needs to be expanded explicitly and allowed spins redetermined
+
+            // aab or bba -> PP2[ab](abc) + PP2[ab](acb) + PP2[ab](cab)
+            if ( spin1 == spin2 && spin1 != spin3 ) {
+
+                // first guy is just a copy plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy1 (new pq_string(tmp[i]->vacuum));
+                newguy1->copy(tmp[i].get());
+
+                // adjust permutations. no more PP6, but we have PP2
+                newguy1->paired_permutations_6.clear();
+                newguy1->paired_permutations_2.push_back(o1);
+                newguy1->paired_permutations_2.push_back(v1);
+                newguy1->paired_permutations_2.push_back(o2);
+                newguy1->paired_permutations_2.push_back(v2);
+
+                // second guy is a copy with permuted pair labels, plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy2 (new pq_string(tmp[i]->vacuum));
+                newguy2->copy(tmp[i].get());
+                swap_two_labels(newguy2, o2, o3);
+                swap_two_labels(newguy2, v2, v3);
+
+                // reset non-summed spins for this guy
+                newguy2->reset_spin_labels();
+
+                // no more PP6, but we have PP2
+                newguy2->paired_permutations_6.clear();
+                newguy2->paired_permutations_2.push_back(o1);
+                newguy2->paired_permutations_2.push_back(v1);
+                newguy2->paired_permutations_2.push_back(o2);
+                newguy2->paired_permutations_2.push_back(v2);
+
+                // third guy is another copy with permuted pair labels, plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy3 (new pq_string(tmp[i]->vacuum));
+                newguy3->copy(tmp[i].get());
+                swap_two_labels(newguy3, o1, o2);
+                swap_two_labels(newguy3, v1, v2);
+                swap_two_labels(newguy3, o2, o3);
+                swap_two_labels(newguy3, v2, v3);
+
+                // reset non-summed spins for this guy
+                newguy3->reset_spin_labels();
+
+                // no more PP6, but we have PP2
+                newguy3->paired_permutations_6.clear();
+                newguy3->paired_permutations_2.push_back(o1);
+                newguy3->paired_permutations_2.push_back(v1);
+                newguy3->paired_permutations_2.push_back(o2);
+                newguy3->paired_permutations_2.push_back(v2);
+
+                for (size_t k = 0; k < n; k++) {
+
+                    // skip jth permutation, which is the one we expanded
+                    if ( j == k ) continue;
+
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+
+                }
+
+                tmp[i]->skip = true;
+                tmp.push_back(newguy1);
+                tmp.push_back(newguy2);
+                tmp.push_back(newguy3);
+
+                // break loop over permutations because this above logic only works on one permutation at a time
+                break;
+            }
+            // abb or baa -> PP2[bc](abc) + PP2[bc](bac) + PP2[bc](bca)
+            else if ( spin1 != spin2 && spin2 == spin3 ) {
+
+                // first guy is just a copy plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy1 (new pq_string(tmp[i]->vacuum));
+                newguy1->copy(tmp[i].get());
+
+                // adjust permutations. no more PP6, but we have PP2
+                newguy1->paired_permutations_6.clear();
+                newguy1->paired_permutations_2.push_back(o2);
+                newguy1->paired_permutations_2.push_back(v2);
+                newguy1->paired_permutations_2.push_back(o3);
+                newguy1->paired_permutations_2.push_back(v3);
+
+                // second guy is a copy with permuted pair labels, plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy2 (new pq_string(tmp[i]->vacuum));
+                newguy2->copy(tmp[i].get());
+                swap_two_labels(newguy2, o1, o2);
+                swap_two_labels(newguy2, v1, v2);
+
+                // reset non-summed spins for this guy
+                newguy2->reset_spin_labels();
+
+                // no more PP6, but we have PP2
+                newguy2->paired_permutations_6.clear();
+                newguy2->paired_permutations_2.push_back(o2);
+                newguy2->paired_permutations_2.push_back(v2);
+                newguy2->paired_permutations_2.push_back(o3);
+                newguy2->paired_permutations_2.push_back(v3);
+
+                // third guy is another copy with permuted pair labels, plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy3 (new pq_string(tmp[i]->vacuum));
+                newguy3->copy(tmp[i].get());
+                swap_two_labels(newguy3, o1, o2);
+                swap_two_labels(newguy3, v1, v2);
+                swap_two_labels(newguy3, o1, o3);
+                swap_two_labels(newguy3, v1, v3);
+
+                // reset non-summed spins for this guy
+                newguy3->reset_spin_labels();
+
+                // no more PP6, but we have PP2
+                newguy3->paired_permutations_6.clear();
+                newguy3->paired_permutations_2.push_back(o2);
+                newguy3->paired_permutations_2.push_back(v2);
+                newguy3->paired_permutations_2.push_back(o3);
+                newguy3->paired_permutations_2.push_back(v3);
+
+                for (size_t k = 0; k < n; k++) {
+
+                    // skip jth permutation, which is the one we expanded
+                    if ( j == k ) continue;
+
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+                }
+
+                tmp[i]->skip = true;
+                tmp.push_back(newguy1);
+                tmp.push_back(newguy2);
+                tmp.push_back(newguy3);
+
+                // break loop over permutations because this above logic only works on one permutation at a time
+                break;
+            }
+            // aba or bab -> PP2[ac](abc) + PP2[ac](bac) + PP2[ac](acb)
+            else if ( spin1 == spin2 && spin1 != spin3 ) {
+
+                // first guy is just a copy plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy1 (new pq_string(tmp[i]->vacuum));
+                newguy1->copy(tmp[i].get());
+
+                // adjust permutations. no more PP6, but we have PP2
+                newguy1->paired_permutations_6.clear();
+                newguy1->paired_permutations_2.push_back(o1);
+                newguy1->paired_permutations_2.push_back(v1);
+                newguy1->paired_permutations_2.push_back(o3);
+                newguy1->paired_permutations_2.push_back(v3);
+
+                // second guy is a copy with permuted pair labels, plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy2 (new pq_string(tmp[i]->vacuum));
+                newguy2->copy(tmp[i].get());
+                swap_two_labels(newguy2, o1, o2);
+                swap_two_labels(newguy2, v1, v2);
+
+                // reset non-summed spins for this guy
+                newguy2->reset_spin_labels();
+
+                // no more PP6, but we have PP2
+                newguy2->paired_permutations_6.clear();
+                newguy2->paired_permutations_2.push_back(o1);
+                newguy2->paired_permutations_2.push_back(v1);
+                newguy2->paired_permutations_2.push_back(o3);
+                newguy2->paired_permutations_2.push_back(v3);
+
+                // third guy is another copy with permuted pair labels, plus a PP2 permutation
+                std::shared_ptr<pq_string> newguy3 (new pq_string(tmp[i]->vacuum));
+                newguy3->copy(tmp[i].get());
+                swap_two_labels(newguy3, o2, o3);
+                swap_two_labels(newguy3, v2, v3);
+
+                // reset non-summed spins for this guy
+                newguy3->reset_spin_labels();
+
+                // no more PP6, but we have PP2
+                newguy3->paired_permutations_6.clear();
+                newguy3->paired_permutations_2.push_back(o1);
+                newguy3->paired_permutations_2.push_back(v1);
+                newguy3->paired_permutations_2.push_back(o3);
+                newguy3->paired_permutations_2.push_back(v3);
+
+                for (size_t k = 0; k < n; k++) {
+
+                    // skip jth permutation, which is the one we expanded
+                    if ( j == k ) continue;
+
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy1->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy2->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+1]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+2]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+3]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+4]);
+                    newguy3->paired_permutations_6.push_back(tmp[i]->paired_permutations_6[6*k+5]);
+
+                }
+
+                tmp[i]->skip = true;
+                tmp.push_back(newguy1);
+                tmp.push_back(newguy2);
+                tmp.push_back(newguy3);
 
                 // break loop over permutations because this above logic only works on one permutation at a time
                 break;

--- a/pdaggerq/pq_utils.cc
+++ b/pdaggerq/pq_utils.cc
@@ -1099,7 +1099,7 @@ void alphabetize(std::vector<std::shared_ptr<pq_string> > &ordered) {
 }
 
 // compare strings and remove terms that cancel
-void cleanup(std::vector<std::shared_ptr<pq_string> > &ordered) {
+void cleanup(std::vector<std::shared_ptr<pq_string> > &ordered, bool find_paired_permutations) {
 
     for (size_t i = 0; i < ordered.size(); i++) {
 
@@ -1152,12 +1152,15 @@ void cleanup(std::vector<std::shared_ptr<pq_string> > &ordered) {
     if ( ordered[0]->vacuum != "FERMI" ) return;
 
     // look for paired permutations of non-summed labels:
+    if ( find_paired_permutations ) {
 
-    // a) PP6(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + R(ikj;acb) + R(jik;bac) + R(jki;bca) + R(kij;cab) + R(kji;cba)
-    consolidate_paired_permutations_non_summed(ordered, occ_labels, vir_labels, 6);
+        // a) PP6(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + R(ikj;acb) + R(jik;bac) + R(jki;bca) + R(kij;cab) + R(kji;cba)
+        consolidate_paired_permutations_non_summed(ordered, occ_labels, vir_labels, 6);
 
-    // b) PP3(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + (jik;bac) + R(kji;cba)
-    consolidate_paired_permutations_non_summed(ordered, occ_labels, vir_labels, 3);
+        // b) PP3(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + (jik;bac) + R(kji;cba)
+        consolidate_paired_permutations_non_summed(ordered, occ_labels, vir_labels, 3);
+
+    }
 
     consolidate_permutations_non_summed(ordered, occ_labels);
     consolidate_permutations_non_summed(ordered, vir_labels);
@@ -2680,7 +2683,7 @@ void spin_blocking(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq
 }
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_true_vacuum(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level){
+void add_new_string_true_vacuum(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations){
 
     if ( in->factor > 0.0 ) {
         in->sign = 1;
@@ -2735,11 +2738,11 @@ void add_new_string_true_vacuum(std::shared_ptr<pq_string> in, std::vector<std::
     alphabetize(ordered);
 
     // try to cancel similar terms
-    cleanup(ordered);
+    cleanup(ordered, find_paired_permutations);
 }
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_fermi_vacuum(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level){
+void add_new_string_fermi_vacuum(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations){
         
     // if normal order is defined with respect to the fermi vacuum, we must
     // check here if the input string contains any general-index operators

--- a/pdaggerq/pq_utils.h
+++ b/pdaggerq/pq_utils.h
@@ -93,6 +93,14 @@ void consolidate_permutations_non_summed(
     std::vector<std::shared_ptr<pq_string> > &ordered,
     std::vector<std::string> labels);
 
+// look for paired permutations of non-summed labels
+// a) P3a(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + R(ikj;acb) + R(jik;bac) + R(jki;bca) + R(kij;cab) + R(kji;cba)
+// b) P3b(i,a;j,b;k,c) R(ijk;abc) = R(ijk;abc) + (jik;bac) + R(kji;cba)
+void consolidate_paired_permutations_non_summed(
+    std::vector<std::shared_ptr<pq_string> > &ordered,
+    std::vector<std::string> occ_labels,
+    std::vector<std::string> vir_labels);
+
 /// alphabetize operators to simplify string comparisons (for true vacuum only)
 void alphabetize(std::vector<std::shared_ptr<pq_string> > &ordered);
 

--- a/pdaggerq/pq_utils.h
+++ b/pdaggerq/pq_utils.h
@@ -88,6 +88,11 @@ bool compare_integrals( std::vector<integrals> ints1,
 void consolidate_permutations_plus_swaps(std::vector<std::shared_ptr<pq_string> > &ordered,
                                          std::vector<std::vector<std::string> > labels);
 
+// consolidate terms that differ by permutations of non-summed labels
+void consolidate_permutations_non_summed(
+    std::vector<std::shared_ptr<pq_string> > &ordered,
+    std::vector<std::string> labels);
+
 /// alphabetize operators to simplify string comparisons (for true vacuum only)
 void alphabetize(std::vector<std::shared_ptr<pq_string> > &ordered);
 

--- a/pdaggerq/pq_utils.h
+++ b/pdaggerq/pq_utils.h
@@ -102,6 +102,21 @@ void consolidate_paired_permutations_non_summed(
     std::vector<std::string> vir_labels,
     int n_fold);
 
+/// compare two strings when swapping (multiple) summed labels and ov pairs of nonsumed labels
+void compare_strings_with_swapped_summed_and_nonsummed_labels(
+    std::vector<std::vector<std::string> > labels,
+    std::vector<std::vector<std::string>> pairs,
+    size_t iter,
+    std::shared_ptr<pq_string> in1,
+    std::shared_ptr<pq_string> in2,
+    size_t in2_id,
+    std::vector<size_t> &my_permutations,
+    std::vector<bool> &permutation_types,
+    int n_permutation_type,
+    int & n_permute,
+    bool & strings_same,
+    bool & found_paired_permutation);
+
 /// alphabetize operators to simplify string comparisons (for true vacuum only)
 void alphabetize(std::vector<std::shared_ptr<pq_string> > &ordered);
 

--- a/pdaggerq/pq_utils.h
+++ b/pdaggerq/pq_utils.h
@@ -99,7 +99,8 @@ void consolidate_permutations_non_summed(
 void consolidate_paired_permutations_non_summed(
     std::vector<std::shared_ptr<pq_string> > &ordered,
     std::vector<std::string> occ_labels,
-    std::vector<std::string> vir_labels);
+    std::vector<std::string> vir_labels,
+    int n_fold);
 
 /// alphabetize operators to simplify string comparisons (for true vacuum only)
 void alphabetize(std::vector<std::shared_ptr<pq_string> > &ordered);

--- a/pdaggerq/pq_utils.h
+++ b/pdaggerq/pq_utils.h
@@ -106,7 +106,7 @@ void consolidate_paired_permutations_non_summed(
 void alphabetize(std::vector<std::shared_ptr<pq_string> > &ordered);
 
 /// cancel terms where appropriate
-void cleanup(std::vector<std::shared_ptr<pq_string> > &ordered);
+void cleanup(std::vector<std::shared_ptr<pq_string> > &ordered, bool find_paired_permutations);
 
 /// reorder t amplitudes as t1, t2, t3, t4
 void reorder_t_amplitudes(std::shared_ptr<pq_string> in);
@@ -133,10 +133,10 @@ bool add_spins(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_str
 void spin_blocking(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &spin_blocked, std::map<std::string, std::string> spin_map);
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_true_vacuum(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level);
+void add_new_string_true_vacuum(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations);
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_fermi_vacuum(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level);
+void add_new_string_fermi_vacuum(std::shared_ptr<pq_string> in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations);
 
 /// concatinate a list of operators (a list of strings) into a single list
 std::vector<std::string> concatinate_operators(std::vector<std::vector<std::string>> ops);


### PR DESCRIPTION
adds logic to find paired ov-type permutations that arise in in CCSDT. the code generators do not yet recognize the PP2, PP3, and PP6 permutations, so this behavior is currently disabled by default. can be enabled with set_find_paired_permutations(True)