### PR TITLE
It seems like it's better to just rely on the pybind11 package to fin…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,18 +25,10 @@ project(pdaggerq LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# find python and set variables for:
-#     the interpreter, include dirs, libraries, and version
-set(Python3_FIND_STRATEGY LOCATION)
-find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
-set(PYTHON_EXECUTABLE   ${Python3_EXECUTABLE})
-set(PYTHON_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
-set(PYTHON_LIBRARIES    ${Python3_LIBRARIES})
-set(PYTHON_VERSION      ${Python3_VERSION})
-
-# find pybind11 and set variables for:
+# find pybind11 and set variables for finding the correct python version
 set(PYBIND11_PYTHON_VERSION 3)
 set(PYBIND11_FINDPYTHON ON)
+set(Python3_FIND_STRATEGY LOCATION)
 
 include(FetchContent)
 FetchContent_Declare(


### PR DESCRIPTION
There isn't a reason to manually find and set the python package in CMake when we can rely on Pybind11 to get python. We had added the manual search for python before since Pybind11 would grab the wrong version of python. However, Pybind11 will now find the correct python by keeping the `Python3_FIND_STRATEGY` variable set to `location` and using the other variables set with Pybind11: `PYBIND11_PYTHON_VERSION` and `PYBIND11_FINDPYTHON`