### PR TITLE
removal of factoring logic

### DIFF
--- a/pq_graph/include/linkage.h
+++ b/pq_graph/include/linkage.h
@@ -188,7 +188,7 @@ namespace pdaggerq {
          * fuses together similar sublinkages
          * @return true if the linkage was fused, false otherwise
          */
-        bool fuse();
+        bool factor();
 
         /**
          * Merges constants together in linkage

--- a/pq_graph/include/pq_graph.h
+++ b/pq_graph/include/pq_graph.h
@@ -228,7 +228,7 @@ namespace pdaggerq {
         size_t merge_terms();
 
         /**
-         * fuse intermediate terms with the same rhs
+         * factor intermediate terms with the same rhs
          */
         size_t merge_intermediates();
 

--- a/pq_graph/src/fusion.cc
+++ b/pq_graph/src/fusion.cc
@@ -605,7 +605,7 @@ struct LinkMerger {
                     merged_pq += " += " + merge_term->original_pq_;
                 }
 
-                as_link(merged_vertex)->fuse();
+                as_link(merged_vertex)->factor();
                 bool last_add_bool = merged_vertex->is_addition();
                 as_link(merged_vertex)->copy_misc(target_infos[i].link);
                 as_link(merged_vertex)->is_addition() = last_add_bool;
@@ -614,7 +614,7 @@ struct LinkMerger {
                 if (i == 0) {
                     merged_vertex_init = merged_vertex->relabel()->shallow();
                     merged_vertex_init->id() = -1;
-                    as_link(merged_vertex_init)->fuse();
+                    as_link(merged_vertex_init)->factor();
                     as_link(merged_vertex_init)->copy_misc(target_infos[i].link);
                     as_link(merged_vertex_init)->is_addition() = last_add_bool;
                     as_link(merged_vertex_init)->id() = max_id;
@@ -944,10 +944,10 @@ size_t PQGraph::prune(bool keep_single_use) {
         #pragma omp parallel for schedule(guided) default(none) shared(all_terms)
         for (Term *term_ptr: all_terms) {
             Term &term = *term_ptr;
-            // fuse the term linkage
+            // factor the term linkage
             MutableLinkagePtr term_link = as_link(term.term_linkage()->shallow());
             if (!term_link->is_temp()) continue;
-            else term_link->fuse();
+            else term_link->factor();
 
             term.expand_rhs(term_link);
             term.reorder(true);

--- a/pq_graph/src/linkage_ops.cc
+++ b/pq_graph/src/linkage_ops.cc
@@ -200,6 +200,7 @@ namespace pdaggerq {
     }
 
     bool Linkage::fuse() {
+        return false; // TODO: this never works correctly. Needs to eventually.
         if (is_temp() || empty()) return false;
         if (left_->empty() && right_->is_linked()) { *this = *as_link(right_); return false; }
         if (right_->empty() && left_->is_linked()) { *this = *as_link(left_); return false; }

--- a/pq_graph/src/linkage_ops.cc
+++ b/pq_graph/src/linkage_ops.cc
@@ -199,7 +199,7 @@ namespace pdaggerq {
         }
     }
 
-    bool Linkage::fuse() {
+    bool Linkage::factor() {
         return false; // TODO: this never works correctly. Needs to eventually.
         if (is_temp() || empty()) return false;
         if (left_->empty() && right_->is_linked()) { *this = *as_link(right_); return false; }
@@ -210,8 +210,8 @@ namespace pdaggerq {
         MutableVertexPtr right = right_->shallow();
 
         bool made_subfusion = false;
-        if ( left->is_linked() &&  left->is_addition()) made_subfusion |= as_link( left)->fuse();
-        if (right->is_linked() && right->is_addition()) made_subfusion |= as_link(right)->fuse();
+        if ( left->is_linked() &&  left->is_addition()) made_subfusion |= as_link(left)->factor();
+        if (right->is_linked() && right->is_addition()) made_subfusion |= as_link(right)->factor();
 
         bool test_fusion = !left->is_temp() && !right->is_temp();
         test_fusion &= !left->is_addition() && !right->is_addition();
@@ -243,7 +243,7 @@ namespace pdaggerq {
                         return a->lines() < b->lines();
                     });
 
-            // if there are common vertices, fuse them
+            // if there are common vertices, factor them
             if (!common.empty()) {
 
                 vertex_vector new_left, new_right;


### PR DESCRIPTION
removal of factoring logic. The factoring wouldn't work as intended and needlessly made the equations more expensive in some cases. This should be fixed eventually, but it should not be left in the master branch as it is. 