### PR TITLE
Improved printing for non-terminating factors

### DIFF
--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -55,33 +55,29 @@ template <typename T> int minimum_precision(T factor) {
 
     int precision = 0;
     bool decimal_point_encountered = false;
-    bool found_copy = false;
-    char last_char = ' ';
-    int  copy_count = 0;
+    bool is_repeated = false;
+    char last_digit = ' ';
+    int  repeat_count = 0;
 
-    for (char c : str) {
-        found_copy = (c == last_char);
-        last_char = c;
-        if (c == '.') {
+    for (char digit : str) {
+        is_repeated = (digit == last_digit);
+        last_digit = digit;
+        if (digit == '.') {
             decimal_point_encountered = true;
-        } else if (decimal_point_encountered && found_copy) {
-            if (++copy_count >= 4) break;
+        } else if (decimal_point_encountered && is_repeated) {
+            if (++repeat_count >= 4) break; // keep at most 4 repeating digits
         }
 
-        if (!found_copy)
-            copy_count = 0;
+        if (!is_repeated) repeat_count = 0; // reset count
+        if (decimal_point_encountered) precision++; // increment precision
 
-
-        if (decimal_point_encountered) {
-            precision++;
-        }
     }
 
-    if (precision >= copy_count)
-         precision -= copy_count;
-    else precision = 2;
+    // if the last repeating digit is zero, we can reduce the precision
+    if (precision >= repeat_count && last_digit == '0')
+        precision -= repeat_count;
 
-    // always have at least two digits
+    // we should always have at least two digits
     if (precision < 2)
         precision = 2;
 

--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -65,7 +65,7 @@ template <typename T> int minimum_precision(T factor) {
         if (digit == '.') {
             decimal_point_encountered = true;
         } else if (decimal_point_encountered && is_repeated) {
-            if (++repeat_count >= 8) break; // keep at most 8 repeating digits
+            if (++repeat_count >= 12) break; // keep at most 8 repeating digits
         }
 
         if (!is_repeated) repeat_count = 0; // reset count

--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -65,7 +65,7 @@ template <typename T> int minimum_precision(T factor) {
         if (digit == '.') {
             decimal_point_encountered = true;
         } else if (decimal_point_encountered && is_repeated) {
-            if (++repeat_count >= 12) break; // keep at most 8 repeating digits
+            if (++repeat_count >= 12) break; // keep at most 12 repeating digits
         }
 
         if (!is_repeated) repeat_count = 0; // reset count

--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -65,7 +65,7 @@ template <typename T> int minimum_precision(T factor) {
         if (digit == '.') {
             decimal_point_encountered = true;
         } else if (decimal_point_encountered && is_repeated) {
-            if (++repeat_count >= 4) break; // keep at most 4 repeating digits
+            if (++repeat_count >= 8) break; // keep at most 8 repeating digits
         }
 
         if (!is_repeated) repeat_count = 0; // reset count


### PR DESCRIPTION
 non-terminating factors would truncate the value too early for printing (i.e. 1/6 becomes 0.17 instead of 0.16666). Now 0.16666 will be printed (4 repeating digits included). for exact numerical accuracy, we should ideally print 0.1666666666666. This is incredibly ugly. The truncated values shouldn't contribute to numerical error as much as various steps in a many-body method.
 
Perhaps it will be better to approximate the fraction to directly print out 1.0 / 6.0. This had existed before, but was removed. This requires much more refactoring, however.