### PR TITLE
RDM fix

### DIFF
--- a/pdaggerq/pq_add_label_ranges.cc
+++ b/pdaggerq/pq_add_label_ranges.cc
@@ -32,57 +32,26 @@ namespace pdaggerq {
 /// expand sums to account for different orbital ranges and zero terms where appropriate
 void add_label_ranges(const std::shared_ptr<pq_string>& in, std::vector<std::shared_ptr<pq_string> > &range_blocked, const std::unordered_map<std::string, std::vector<std::string>> &label_ranges) {
 
-    // check that non-summed label ranges match those specified
-    static std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
-    static std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
-
-    std::map<std::string, bool> found_labels;
-   
-    // ok, what non-summed labels do we have in the occupied space? 
-    for (const std::string & occ_label : occ_labels) {
-        int found = index_in_anywhere(in, occ_label);
-        if ( found == 1 ) {
-            found_labels[occ_label] = true;
-        }else{
-            found_labels[occ_label] = false;
-        }
-    }
-   
-    // ok, what non-summed labels do we have in the virtual space? 
-    for (const std::string & vir_label : vir_labels) {
-        int found = index_in_anywhere(in, vir_label);
-        if ( found == 1 ) {
-            found_labels[vir_label] = true;
-        }else{
-            found_labels[vir_label] = false;
-        }
-    }
-
-    for (const std::string & occ_label : occ_labels) {
-        if ( found_labels[occ_label] ) {
-            // find label range
-            auto pos = label_ranges.find(occ_label);
-            std::vector<std::string> label_range = pos == label_ranges.end() ? std::vector<std::string>() : pos->second;
-            
-
-            if ( label_range[0] != "act" && label_range[0] != "ext" ) {
-                printf("\n");
-                printf("    error: label range for non-summed index %s is invalid\n", occ_label.c_str());
-                printf("\n");
-                exit(1);
-            }
-        }
-    }
-    for (const std::string & vir_label : vir_labels) {
-        if ( found_labels[vir_label] ) {
-            auto pos = label_ranges.find(vir_label);
-            std::vector<std::string> label_range = pos == label_ranges.end() ? std::vector<std::string>() : pos->second;
-
-            if ( label_range[0] != "act" && label_range[0] != "ext" ) {
-                printf("\n");
-                printf("    error: label ranges for non-summed index %s is invalid\n", vir_label.c_str());
-                printf("\n");
-                exit(1);
+    // check that label ranges are valid
+    for (auto item : label_ranges) {
+        
+        for (auto range : item.second) {
+            // non-summed index? not perfect logic ...
+            int found = index_in_anywhere(in, item.first);
+            if ( found == 1 ) {
+                if ( range != "act" && range != "ext" ) {
+                    printf("\n");
+                    printf("    error: label range for non-summed label %s is invalid\n", item.first.c_str());
+                    printf("\n");
+                    exit(1);
+                }
+            }else {
+                if ( range != "act" && range != "ext" && range != "all" ) {
+                    printf("\n");
+                    printf("    error: label range for %s is invalid\n", item.first.c_str());
+                    printf("\n");
+                    exit(1);
+                }
             }
         }
     }

--- a/pdaggerq/pq_add_label_ranges.cc
+++ b/pdaggerq/pq_add_label_ranges.cc
@@ -33,8 +33,8 @@ namespace pdaggerq {
 void add_label_ranges(const std::shared_ptr<pq_string>& in, std::vector<std::shared_ptr<pq_string> > &range_blocked, const std::unordered_map<std::string, std::vector<std::string>> &label_ranges) {
 
     // check that non-summed label ranges match those specified
-    static std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "o" };
-    static std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "g" };
+    static std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
+    static std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
 
     std::map<std::string, bool> found_labels;
    

--- a/pdaggerq/pq_add_label_ranges.cc
+++ b/pdaggerq/pq_add_label_ranges.cc
@@ -37,7 +37,7 @@ void add_label_ranges(const std::shared_ptr<pq_string>& in, std::vector<std::sha
         
         for (auto range : item.second) {
             // non-summed index? not perfect logic ...
-            int found = index_in_anywhere(in, item.first);
+            int found = in->index_in_anywhere(item.first);
             if ( found == 1 ) {
                 if ( range != "act" && range != "ext" ) {
                     printf("\n");

--- a/pdaggerq/pq_add_label_ranges.cc
+++ b/pdaggerq/pq_add_label_ranges.cc
@@ -56,6 +56,62 @@ void add_label_ranges(const std::shared_ptr<pq_string>& in, std::vector<std::sha
         }
     }
 
+    // check if label range map is missing any of the non-summed spin 
+    // labels. note that the logic here might not be perfect since the 
+    // keys in the label_ranges map can be non-summed labels or 
+    // amplitude types (e.g., t1, t2, ...)
+
+    // amplitudes
+    for (auto &amps_pair : in->amps) {
+        char type = amps_pair.first;
+        std::vector<amplitudes> &amps_vec = amps_pair.second;
+        for (amplitudes & amp : amps_vec) {
+            for (size_t k = 0; k < amp.labels.size(); k++) {
+                int n = in->index_in_anywhere(amp.labels[k]);
+                if ( n != 1 ) continue;
+                int found = label_ranges.count(amp.labels[k]);
+                if ( found == 0 ) {
+                    printf("\n");
+                    printf("    error: label range for non-summed index %s has not been set\n", amp.labels[k].c_str());
+                    printf("\n");
+                    exit(1);
+                }
+            }
+        }
+    }
+    // integrals
+    for (auto &ints_pair : in->ints) {
+        std::string type = ints_pair.first;
+        std::vector<integrals> &ints_vec = ints_pair.second;
+        for (integrals & integral : ints_vec) {
+            for (size_t k = 0; k < integral.labels.size(); k++) {
+                int n = in->index_in_anywhere(integral.labels[k]);
+                if ( n != 1 ) continue;
+                int found = label_ranges.count(integral.labels[k]);
+                if ( found == 0 ) {
+                    printf("\n");
+                    printf("    error: label range for non-summed index %s has not been set\n", integral.labels[k].c_str());
+                    printf("\n");
+                    exit(1);
+                }
+            }
+        }
+    }
+    // deltas
+    for (delta_functions & delta : in->deltas) {
+        for (size_t j = 0; j < delta.labels.size(); j++) {
+            int n = in->index_in_anywhere(delta.labels[j]);
+            if ( n != 1 ) continue;
+            int found = label_ranges.count(delta.labels[j]);
+            if ( found == 0 ) {
+                printf("\n");
+                printf("    error: label range for non-summed index %s has not been set\n", delta.labels[j].c_str());
+                printf("\n");
+                exit(1);
+            }
+        }
+    }
+
     std::shared_ptr<pq_string> newguy (new pq_string(in->vacuum));
     newguy->copy(in.get());
 

--- a/pdaggerq/pq_add_spin_labels.cc
+++ b/pdaggerq/pq_add_spin_labels.cc
@@ -335,8 +335,8 @@ bool add_spins(const std::shared_ptr<pq_string>& in, std::vector<std::shared_ptr
 void spin_blocking(const std::shared_ptr<pq_string>& in, std::vector<std::shared_ptr<pq_string> > &spin_blocked, const std::unordered_map<std::string, std::string> &spin_map) {
 
     // check that non-summed spin labels match those specified
-    static std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "o" };
-    static std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "g" };
+    static std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
+    static std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
 
     std::map<std::string, bool> found_labels;
     

--- a/pdaggerq/pq_add_spin_labels.cc
+++ b/pdaggerq/pq_add_spin_labels.cc
@@ -334,6 +334,60 @@ bool add_spins(const std::shared_ptr<pq_string>& in, std::vector<std::shared_ptr
 // expand sums to include spin and zero terms where appropriate
 void spin_blocking(const std::shared_ptr<pq_string>& in, std::vector<std::shared_ptr<pq_string> > &spin_blocked, const std::unordered_map<std::string, std::string> &spin_map) {
 
+    // check if spin map is missing any of the non-summed spin labels
+
+    // amplitudes
+    for (auto &amps_pair : in->amps) {
+        char type = amps_pair.first;
+        std::vector<amplitudes> &amps_vec = amps_pair.second;
+        for (amplitudes & amp : amps_vec) {
+            for (size_t k = 0; k < amp.labels.size(); k++) {
+                int n = in->index_in_anywhere(amp.labels[k]);
+                if ( n != 1 ) continue;
+                int found = spin_map.count(amp.labels[k]);
+                if ( found == 0 ) {
+                    printf("\n");
+                    printf("    error: spin label for non-summed index %s has not been set\n", amp.labels[k].c_str());
+                    printf("\n");
+                    exit(1);
+                }
+            }
+        }
+    }
+    // integrals
+    for (auto &ints_pair : in->ints) {
+        std::string type = ints_pair.first;
+        std::vector<integrals> &ints_vec = ints_pair.second;
+        for (integrals & integral : ints_vec) {
+            for (size_t k = 0; k < integral.labels.size(); k++) {
+                int n = in->index_in_anywhere(integral.labels[k]);
+                if ( n != 1 ) continue;
+                int found = spin_map.count(integral.labels[k]);
+                if ( found == 0 ) {
+                    printf("\n");
+                    printf("    error: spin label for non-summed index %s has not been set\n", integral.labels[k].c_str());
+                    printf("\n");
+                    exit(1);
+                }
+            }
+        }
+    }
+    // deltas
+    for (delta_functions & delta : in->deltas) {
+        for (size_t j = 0; j < delta.labels.size(); j++) {
+            int n = in->index_in_anywhere(delta.labels[j]);
+            if ( n != 1 ) continue;
+            int found = spin_map.count(delta.labels[j]);
+            if ( found == 0 ) {
+                printf("\n");
+                printf("    error: spin label for non-summed index %s has not been set\n", delta.labels[j].c_str());
+                printf("\n");
+                exit(1);
+            }
+        }
+    }
+    
+
     // check that spin labels are valid
     for (auto item : spin_map) {
         if ( item.second != "a" && item.second != "b" ) {

--- a/pdaggerq/pq_add_spin_labels.cc
+++ b/pdaggerq/pq_add_spin_labels.cc
@@ -336,12 +336,9 @@ void spin_blocking(const std::shared_ptr<pq_string>& in, std::vector<std::shared
 
     // check that spin labels are valid
     for (auto item : spin_map) {
-    
-        std::string spin_label = item.second;
-
-        if ( spin_label != "a" && spin_label != "b" ) {
+        if ( item.second != "a" && item.second != "b" ) {
             printf("\n");
-            printf("    error: spin label for non-summed index %s is invalid\n", spin_label.c_str());
+            printf("    error: spin label for non-summed index %s is invalid\n", item.first.c_str());
             printf("\n");
             exit(1);
         }

--- a/pdaggerq/pq_add_spin_labels.cc
+++ b/pdaggerq/pq_add_spin_labels.cc
@@ -386,7 +386,6 @@ void spin_blocking(const std::shared_ptr<pq_string>& in, std::vector<std::shared
             }
         }
     }
-    
 
     // check that spin labels are valid
     for (auto item : spin_map) {

--- a/pdaggerq/pq_add_spin_labels.cc
+++ b/pdaggerq/pq_add_spin_labels.cc
@@ -334,60 +334,16 @@ bool add_spins(const std::shared_ptr<pq_string>& in, std::vector<std::shared_ptr
 // expand sums to include spin and zero terms where appropriate
 void spin_blocking(const std::shared_ptr<pq_string>& in, std::vector<std::shared_ptr<pq_string> > &spin_blocked, const std::unordered_map<std::string, std::string> &spin_map) {
 
-    // check that non-summed spin labels match those specified
-    static std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
-    static std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
-
-    std::map<std::string, bool> found_labels;
+    // check that spin labels are valid
+    for (auto item : spin_map) {
     
-    // ok, what non-summed labels do we have in the occupied space? 
-    for (const std::string & occ_label : occ_labels) {
-        int found = index_in_anywhere(in, occ_label);
-        if ( found == 1 ) {
-            found_labels[occ_label] = true;
-        }else{
-            found_labels[occ_label] = false;
-        }
-    }
-    
-    // ok, what non-summed labels do we have in the virtual space? 
-    for (const std::string & vir_label : vir_labels) {
-        int found = index_in_anywhere(in, vir_label);
-        if ( found == 1 ) {
-            found_labels[vir_label] = true;
-        }else{
-            found_labels[vir_label] = false;
-        }
-    }
+        std::string spin_label = item.second;
 
-    for (const std::string & occ_label : occ_labels) {
-        if ( found_labels[occ_label] ) {
-            // find spin label
-            auto pos = spin_map.find(occ_label);
-            std::string spin_label = pos == spin_map.end() ? "" : pos->second;
-
-            // check if spin label is valid
-            if ( spin_label != "a" && spin_label != "b" ) {
-                printf("\n");
-                printf("    error: spin label for non-summed index %s is invalid\n", occ_label.c_str());
-                printf("\n");
-                exit(1);
-            }
-        }
-    }
-    for (const std::string & vir_label : vir_labels) {
-        if ( found_labels[vir_label] ) {
-            // find spin label
-            auto pos = spin_map.find(vir_label);
-            std::string spin_label = pos == spin_map.end() ? "" : pos->second;
-
-            // check if spin label is valid
-            if ( spin_label != "a" && spin_label != "b" ) {
-                printf("\n");
-                printf("    error: spin label for non-summed index %s is invalid\n", vir_label.c_str());
-                printf("\n");
-                exit(1);
-            }
+        if ( spin_label != "a" && spin_label != "b" ) {
+            printf("\n");
+            printf("    error: spin label for non-summed index %s is invalid\n", spin_label.c_str());
+            printf("\n");
+            exit(1);
         }
     }
 

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -201,7 +201,6 @@ pq_helper::pq_helper(const pq_helper &other) {
     for (const std::shared_ptr<pq_string> & pq_str : other.ordered_blocked) {
         this->ordered_blocked.push_back(std::make_shared<pq_string>(*pq_str));
     }
-
 }
 
 pq_helper &pq_helper::operator=(const pq_helper &other) {

--- a/pdaggerq/pq_string.cc
+++ b/pdaggerq/pq_string.cc
@@ -805,12 +805,11 @@ void pq_string::reset_spin_labels() {
         }
     }
 
-    std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
-    std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
 
-    // set spins for occupied non-summed labels
-    for (const std::string & occ_label : occ_labels) {
-        std::string spin = non_summed_spin_labels[occ_label];
+    // set spins for labels in the spin map
+    for (auto item : non_summed_spin_labels ) {
+        std::string label = item.first;
+        std::string spin = item.second;
         if ( spin == "a" || spin == "b" ) {
             // amplitudes
             for (auto &amps_pair : amps) {
@@ -818,7 +817,7 @@ void pq_string::reset_spin_labels() {
                 std::vector<amplitudes> &amps_vec = amps_pair.second;
                 for (amplitudes & amp : amps_vec) {
                     for (size_t k = 0; k < amp.labels.size(); k++) {
-                        if ( amp.labels[k] == occ_label ) {
+                        if ( amp.labels[k] == label ) {
                             amp.spin_labels[k] = spin;
                         }
                     }
@@ -830,7 +829,7 @@ void pq_string::reset_spin_labels() {
                 std::vector<integrals> &ints_vec = ints_pair.second;
                 for (integrals & integral : ints_vec) {
                     for (size_t k = 0; k < integral.labels.size(); k++) {
-                        if ( integral.labels[k] == occ_label ) {
+                        if ( integral.labels[k] == label ) {
                             integral.spin_labels[k] = spin;
                         }
                     }
@@ -839,46 +838,7 @@ void pq_string::reset_spin_labels() {
             // deltas
             for (delta_functions & delta : deltas) {
                 for (size_t j = 0; j < delta.labels.size(); j++) {
-                    if ( delta.labels[j] == occ_label ) {
-                        delta.spin_labels[j] = spin;
-                    }
-                }
-            }
-        }
-    }
-
-    // set spins for virtual non-summed labels
-    for (const auto & vir_label : vir_labels) {
-        std::string spin = non_summed_spin_labels[vir_label];
-        if ( spin == "a" || spin == "b" ) {
-            // amplitudes
-            for (auto &amps_pair : amps) {
-                char type = amps_pair.first;
-                std::vector<amplitudes> &amps_vec = amps_pair.second;
-                for (amplitudes & amp : amps_vec) {
-                    for (size_t k = 0; k < amp.labels.size(); k++) {
-                        if ( amp.labels[k] == vir_label ) {
-                            amp.spin_labels[k] = spin;
-                        }
-                    }
-                }
-            }
-            // integrals
-            for (auto &ints_pair : ints) {
-                std::string type = ints_pair.first;
-                std::vector<integrals> &ints_vec = ints_pair.second;
-                for (integrals & integral : ints_vec) {
-                    for (size_t k = 0; k < integral.labels.size(); k++) {
-                        if ( integral.labels[k] == vir_label ) {
-                            integral.spin_labels[k] = spin;
-                        }
-                    }
-                }
-            }
-            // deltas
-            for (delta_functions & delta : deltas) {
-                for (size_t j = 0; j < delta.labels.size(); j++) {
-                    if ( delta.labels[j] == vir_label ) {
+                    if ( delta.labels[j] == label ) {
                         delta.spin_labels[j] = spin;
                     }
                 }

--- a/pdaggerq/pq_string.cc
+++ b/pdaggerq/pq_string.cc
@@ -23,6 +23,7 @@
 
 #include "pq_string.h"
 #include "pq_tensor.h"
+#include "pq_utils.h"
 
 #include<vector>
 #include<iostream>
@@ -805,7 +806,6 @@ void pq_string::reset_spin_labels() {
         }
     }
 
-
     // set spins for labels in the spin map
     for (auto item : non_summed_spin_labels ) {
         std::string label = item.first;
@@ -913,102 +913,55 @@ void pq_string::reset_label_ranges(const std::unordered_map<std::string, std::ve
         }
     }
 
-    std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
-    std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
+    // set ranges for non-summed labels
+    for (auto item : label_ranges) {
+        
+        for (auto range : item.second) {
 
-    // set ranges for occupied non-summed labels
-    for (const std::string & occ_label : occ_labels) {
+            std::string label = item.first;
 
-        // check that this label is in the map
-        auto range_pos = label_ranges.find(occ_label);
-        if ( range_pos == label_ranges.end() ) continue;
-
-        std::string range = range_pos->second[0];
-
-        if ( range == "act" || range == "ext" ) {
-            // amplitudes
-            for (auto &amp_pair : amps) {
-                char type = amp_pair.first;
-                for (amplitudes & amp : amp_pair.second) {
-                    for (size_t k = 0; k < amp.labels.size(); k++) {
-                        if ( amp.labels[k] == occ_label ) {
-                            amp.label_ranges[k] = range;
+            // non-summed index? not perfect logic ...
+            int found = index_in_anywhere(shared_from_this(), label);
+            if ( found == 1 ) {
+                std::string range = item.second[0];
+                if ( range == "act" || range == "ext" ) {
+                    // amplitudes
+                    for (auto &amp_pair : amps) {
+                        char type = amp_pair.first;
+                        for (amplitudes & amp : amp_pair.second) {
+                            for (size_t k = 0; k < amp.labels.size(); k++) {
+                                if ( amp.labels[k] == label ) {
+                                    amp.label_ranges[k] = range;
+                                }
+                            }
                         }
                     }
-                }
-            }
-            // integrals
-            for (auto &int_pair : ints) {
-                std::string type = int_pair.first;
-                for (integrals & integral : int_pair.second) {
-                    for (size_t k = 0; k < integral.labels.size(); k++) {
-                        if ( integral.labels[k] == occ_label ) {
-                            integral.label_ranges[k] = range;
+                    // integrals
+                    for (auto &int_pair : ints) {
+                        std::string type = int_pair.first;
+                        for (integrals & integral : int_pair.second) {
+                            for (size_t k = 0; k < integral.labels.size(); k++) {
+                                if ( integral.labels[k] == label ) {
+                                    integral.label_ranges[k] = range;
+                                }
+                            }
                         }
                     }
-                }
-            }
-            // deltas
-            for (delta_functions & delta : deltas) {
-                for (size_t j = 0; j < delta.labels.size(); j++) {
-                    if ( delta.labels[j] == occ_label ) {
-                        delta.label_ranges[j] = range;
-                    }
-                }
-            }
-        }else {
-            printf("\n");
-            printf("    error: invalid range %s\n", range.c_str());
-            printf("\n");
-            exit(1);
-        }
-    }
-
-    // set ranges for virtual non-summed labels
-    for (const std::string & vir_label : vir_labels) {
-
-        // check that this label is in the map
-        auto range_pos = label_ranges.find(vir_label);
-        if ( range_pos == label_ranges.end() ) continue;
-
-        std::string range = range_pos->second[0];
-
-        if ( range == "act" || range == "ext" ) {
-            // amplitudes
-            for (auto &amp_pair : amps) {
-                char type = amp_pair.first;
-                for (amplitudes & amp : amp_pair.second) {
-                    for (size_t k = 0; k < amp.labels.size(); k++) {
-                        if ( amp.labels[k] == vir_label ) {
-                            amp.label_ranges[k] = range;
+                    // deltas
+                    for (delta_functions & delta : deltas) {
+                        for (size_t j = 0; j < delta.labels.size(); j++) {
+                            if ( delta.labels[j] == label ) {
+                                delta.label_ranges[j] = range;
+                            }
                         }
                     }
+                }else {
+                    printf("\n");
+                    printf("    error: invalid range %s\n", range.c_str());
+                    printf("\n");
+                    exit(1);
                 }
             }
-            // integrals
-            for (auto &int_pair : ints) {
-                std::string type = int_pair.first;
-                for (integrals & integral : int_pair.second) {
-                    for (size_t k = 0; k < integral.labels.size(); k++) {
-                        if ( integral.labels[k] == vir_label ) {
-                            integral.label_ranges[k] = range;
-                        }
-                    }
-                }
-            }
-            // deltas
-            for (delta_functions & delta : deltas) {
-                for (size_t j = 0; j < delta.labels.size(); j++) {
-                    if ( delta.labels[j] == vir_label ) {
-                        delta.label_ranges[j] = range;
-                    }
-                }
-            }
-        }else {
-            printf("\n");
-            printf("    error: invalid range %s\n", range.c_str());
-            printf("\n");
-            exit(1);
         }
     }
 }

--- a/pdaggerq/pq_string.cc
+++ b/pdaggerq/pq_string.cc
@@ -921,7 +921,7 @@ void pq_string::reset_label_ranges(const std::unordered_map<std::string, std::ve
             std::string label = item.first;
 
             // non-summed index? not perfect logic ...
-            int found = index_in_anywhere(shared_from_this(), label);
+            int found = index_in_anywhere(label);
             if ( found == 1 ) {
                 std::string range = item.second[0];
                 if ( range == "act" || range == "ext" ) {
@@ -984,6 +984,32 @@ void pq_string::set_amplitudes(char type, int n_create, int n_annihilate, int n_
     new_amps.n_ph = n_ph;
     new_amps.sort();
     amps[type].push_back(new_amps);
+}
+
+// how many times does an index appear amplitudes, deltas, integrals, and operators?
+int pq_string::index_in_anywhere(const std::string &idx) {
+
+    // find index in deltas
+    int n = index_in_deltas(idx, deltas);
+
+    // find index in integrals
+    for (const auto & int_pair : ints) {
+        const std::string &type = int_pair.first;
+        const std::vector<integrals> &ints = int_pair.second;
+        n += index_in_integrals(idx, ints);
+    }
+
+    // find index in amplitudes
+    for (const auto & amp_pair : amps) {
+        const char &type = amp_pair.first;
+        const std::vector<amplitudes> &amps = amp_pair.second;
+        n += index_in_amplitudes(idx, amps);
+    }
+
+    // find index in operators
+    n += index_in_operators(idx, symbol);
+
+    return n;
 }
 
 }

--- a/pdaggerq/pq_string.cc
+++ b/pdaggerq/pq_string.cc
@@ -805,8 +805,8 @@ void pq_string::reset_spin_labels() {
         }
     }
 
-    std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "o" };
-    std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "g" };
+    std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
+    std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
 
     // set spins for occupied non-summed labels
     for (const std::string & occ_label : occ_labels) {
@@ -953,8 +953,8 @@ void pq_string::reset_label_ranges(const std::unordered_map<std::string, std::ve
         }
     }
 
-    std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "o" };
-    std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "g" };
+    std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
+    std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
 
     // set ranges for occupied non-summed labels
     for (const std::string & occ_label : occ_labels) {

--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -84,7 +84,8 @@ template <typename T> int minimum_precision(T factor) {
     return precision;
 }
 
-class pq_string : public std::enable_shared_from_this<pq_string> {
+class pq_string 
+{
 
   private:
 
@@ -414,6 +415,17 @@ class pq_string : public std::enable_shared_from_this<pq_string> {
      * @param in: the list of labels for the amplitudes
      */
     void set_amplitudes(char type, int n_create, int n_annihilate, int n_ph, const std::vector<std::string> &in);
+
+
+    /** 
+     *
+     * how many times does an index appear amplitudes, deltas, and integrals?
+     *
+     * @param idx: the index
+     * @return: the number of times idx appears in the string
+     *
+     */
+    int index_in_anywhere(const std::string &idx);
 
 };
 

--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -84,7 +84,7 @@ template <typename T> int minimum_precision(T factor) {
     return precision;
 }
 
-class pq_string {
+class pq_string : public std::enable_shared_from_this<pq_string> {
 
   private:
 

--- a/pdaggerq/pq_utils.cc
+++ b/pdaggerq/pq_utils.cc
@@ -24,7 +24,6 @@
 #include "pq_string.h"
 #include "pq_utils.h"
 #include "pq_swap_operators.h"
-#include "pq_add_spin_labels.h"
 
 #include <algorithm>
 #include <numeric>

--- a/pdaggerq/pq_utils.cc
+++ b/pdaggerq/pq_utils.cc
@@ -196,32 +196,6 @@ bool found_index_anywhere(const std::shared_ptr<pq_string> &in, const std::strin
     return false;
 }
 
-// how many times does an index appear amplitudes, deltas, integrals, and operators?
-int index_in_anywhere(const std::shared_ptr<pq_string> &in, const std::string &idx) {
-
-    // find index in deltas
-    int n = index_in_deltas(idx, in->deltas);
-
-    // find index in integrals
-    for (const auto & int_pair : in->ints) {
-        const std::string &type = int_pair.first;
-        const std::vector<integrals> &ints = int_pair.second;
-        n += index_in_integrals(idx, ints);
-    }
-
-    // find index in amplitudes
-    for (const auto & amp_pair : in->amps) {
-        const char &type = amp_pair.first;
-        const std::vector<amplitudes> &amps = amp_pair.second;
-        n += index_in_amplitudes(idx, amps);
-    }
-
-    // find index in operators
-    n += index_in_operators(idx, in->symbol);
-
-    return n;
-}
-
 /// replace one label with another (in a given set of permutations)
 void replace_index_in_permutations(const std::string &old_idx, const std::string &new_idx, std::vector<std::string> &permutations) {
 
@@ -458,7 +432,7 @@ void consolidate_permutations_plus_swaps(std::vector<std::shared_ptr<pq_string> 
             std::vector<std::string> tmp;
             tmp.reserve(label.size());
             for (const auto & index : label) {
-                int found = index_in_anywhere(ordered[i], index);
+                int found = ordered[i]->index_in_anywhere(index);
                 if ( found == 2 ) {
                     tmp.push_back(index);
                 }
@@ -518,7 +492,7 @@ void consolidate_permutations_plus_swaps(std::vector<std::shared_ptr<pq_string> 
             std::vector<std::string> tmp;
             tmp.reserve(label.size());
             for (const auto & index : label) {
-                int found = index_in_anywhere(ordered[i], index);
+                int found = ordered[i]->index_in_anywhere(index);
                 if ( found == 2 ) {
                     tmp.push_back(index);
                 }
@@ -590,7 +564,7 @@ void consolidate_permutations_non_summed(
     
         // ok, what labels do we have? 
         for (const auto & label : labels) {
-            int found = index_in_anywhere(ordered[i], label);
+            int found = ordered[i]->index_in_anywhere(label);
             // this is buggy when existing permutation labels belong to 
             // the same space as the labels we're permuting ... so skip those for now.
             bool same_space = false;
@@ -715,7 +689,7 @@ void consolidate_permutations_non_summed(
     
         // ok, what labels do we have? 
         for (const auto & label : labels) {
-            int found = index_in_anywhere(ordered[i], label);
+            int found = ordered[i]->index_in_anywhere(label);
             // this is buggy when existing permutation labels belong to 
             // the same space as the labels we're permuting ... so skip those for now.
             bool same_space = false;
@@ -1015,7 +989,7 @@ void consolidate_paired_permutations_non_summed(
 
         // ok, what non-summed occupied labels do we have? 
         for (const std::string & occ_label : occ_labels) {
-            int found = index_in_anywhere(ordered[i], occ_label);
+            int found = ordered[i]->index_in_anywhere(occ_label);
             if ( found == 1 ) {
                 found_occ.push_back(occ_label);
             }
@@ -1023,7 +997,7 @@ void consolidate_paired_permutations_non_summed(
 
         // ok, what non-summed virtual labels do we have? 
         for (const std::string & vir_label : vir_labels) {
-            int found = index_in_anywhere(ordered[i], vir_label);
+            int found = ordered[i]->index_in_anywhere(vir_label);
             if ( found == 1 ) {
                 found_vir.push_back(vir_label);
             }
@@ -1031,13 +1005,13 @@ void consolidate_paired_permutations_non_summed(
 
         // ok, what summed labels (occupied and virtual) do we have? 
         for (const std::string & occ_label : occ_labels) {
-            int found = index_in_anywhere(ordered[i], occ_label);
+            int found = ordered[i]->index_in_anywhere(occ_label);
             if ( found == 2 ) {
                 found_summed_occ.push_back(occ_label);
             }
         }
         for (const std::string & vir_label : vir_labels) {
-            int found = index_in_anywhere(ordered[i], vir_label);
+            int found = ordered[i]->index_in_anywhere(vir_label);
             if ( found == 2 ) {
                 found_summed_vir.push_back(vir_label);
             }
@@ -1323,7 +1297,7 @@ void reclassify_integrals(std::shared_ptr<pq_string> &in) {
         int do_skip = -999;
         
         for (size_t i = 0; i < occ_out.size(); i++) {
-            if ( index_in_anywhere(in, occ_out[i]) == 0 ) {
+            if ( in->index_in_anywhere(occ_out[i]) == 0 ) {
                 idx = occ_out[i];
                 do_skip = i;
                 break;
@@ -1410,11 +1384,11 @@ void use_conventional_labels(std::shared_ptr<pq_string> &in) {
 
     for (const std::string & in_idx : gen_in) {
 
-        if (index_in_anywhere(in, in_idx) > 0 ) {
+        if (in->index_in_anywhere(in_idx) > 0 ) {
 
             for (const std::string & out_idx : gen_out) {
 
-                if (index_in_anywhere(in, out_idx) == 0 ) {
+                if (in->index_in_anywhere(out_idx) == 0 ) {
 
                     replace_index_everywhere(in, in_idx, out_idx);
                     break;
@@ -1434,11 +1408,11 @@ void gobble_deltas(std::shared_ptr<pq_string> &in) {
     
         // is delta label 1 in list of summation labels?
         bool have_delta1 = false;    
-        if ( index_in_anywhere(in, delta.labels[0]) == 2 ){
+        if ( in->index_in_anywhere(delta.labels[0]) == 2 ){
             have_delta1 = true;
         }
         bool have_delta2 = false;
-        if ( index_in_anywhere(in, delta.labels[1]) == 2 ){
+        if ( in->index_in_anywhere(delta.labels[1]) == 2 ){
             have_delta2 = true;
         }
 
@@ -1506,7 +1480,7 @@ void gobble_deltas(std::shared_ptr<pq_string> &in) {
          * */
 
         do_continue = false;
-        static char types[] = {'t', 'l', 'r'};
+        static char types[] = {'t', 'l', 'r', 'D'};
         for (auto & type : types) {
             std::vector<amplitudes> & amps = in->amps[type];
             

--- a/pdaggerq/pq_utils.h
+++ b/pdaggerq/pq_utils.h
@@ -56,9 +56,6 @@ int index_in_amplitudes(const std::string &idx, const std::vector<amplitudes> &a
 /// how many times does an index appear in operators (symbol)?
 int index_in_operators(const std::string &idx, const std::vector<std::string> &ops);
 
-/// how many times does an index appear amplitudes, deltas, and integrals?
-int index_in_anywhere(const std::shared_ptr<pq_string> &in, const std::string &idx);
-
 /// replace one label with another (in delta functions)
 void replace_index_in_deltas(const std::string &old_idx, const std::string &new_idx, std::vector<delta_functions> &deltas);
 


### PR DESCRIPTION
This PR fixes spin tracing for use cases involving RDMs and non-summed labels that are not in the set of labels typically deemed as occupied or virtual (e.g., p, q, r, s, t, u, ...). 

as part of this PR, the index_in_anywhere() function is moved to the pq_string class, and checks were added to ensure that spin or label range maps contain all non-summed labels