### PR TITLE
Coefficient printing

### DIFF
--- a/pdaggerq/parser.py
+++ b/pdaggerq/parser.py
@@ -121,11 +121,15 @@ def string_to_baseterm(term_string, occ_idx=OCC_INDICES, virt_idx=VIRT_INDICES):
 
     else:
         # next, extract indices
-        idx = idx_pattern.findall(term_string)[0]
-        # remove '([idx])' to obtain 'op'
-        term_string = term_string.replace(f'({idx})','')
-        idx = [Index(xx, 'occ') if xx in occ_idx
-               else Index(xx, 'virt') for xx in idx.split(',')]
+        idx = idx_pattern.findall(term_string)
+        if len(idx) == 0:
+            idx = []
+        else:
+            idx = idx[0]
+            # remove '([idx])' to obtain 'op'
+            term_string = term_string.replace(f'({idx})','')
+            idx = [Index(xx, 'occ') if xx in occ_idx
+                   else Index(xx, 'virt') for xx in idx.split(',')]
 
         # check if operator is allowed
         # make operator label lowercase from this point on


### PR DESCRIPTION
This PR cleaned up the coefficient printing on the Python-side parser. It involves translating the `minimum_precision()` method under `pq_string` to Python and adding a few extra logics.

In addition, this PR also fixes a small bug where `r0` or `l0` amplitudes were assumed to have indices and would crash the parser.