### PR TITLE
Amplitude clean up

### DIFF
--- a/examples/qed_ccsd_21_codegen.py
+++ b/examples/qed_ccsd_21_codegen.py
@@ -1,0 +1,198 @@
+import pdaggerq
+from pdaggerq.parser import contracted_strings_to_tensor_terms
+import re
+
+def derive_equation(eqs, proj_eqname, ops, coeffs, L = None, R = None, T = None, spin_block = False):
+    """
+    Derive and simplify the equation for the given projection operator.
+
+    Args:
+        proj_eqname (str): Name of the projection equation.
+        P (list): Projection operators.
+        ops (list): Operators.
+        coeffs (list): Coefficients for the operators.
+        T (list): T-operators.
+        eqs (dict): Dictionary to store the derived equations.
+    """
+    pq = pdaggerq.pq_helper("fermi")
+
+    if L is None:
+        L = [['1']]
+    if R is None:
+        R = [['1']]
+
+    # indices pattern looks like '[...]([a-zA-Z],...,[a-zA-Z])'
+    # with ChatGPT's help:
+    # (?<=\() : Positive lookbehind to match ( but not include it in the result.
+    # [^)]+   : Match one or more characters that are not a closing parenthesis ).
+    # (?=\))  : Positive lookahead to match ) but not include it in the result.
+    idx_pattern  = re.compile('(?<=\()[^)]+(?=\))')
+
+    idx = idx_pattern.findall(L[0][-1])
+    if len(idx)==0:
+        idx = None
+    else:
+        tmp = idx[0].split(',')
+        idx = []
+        for i in range(len(tmp)//2):
+            idx.append(tmp[-1-i])
+        for i in range(len(tmp)//2):
+            idx.append(tmp[i])
+
+        idx = tuple(idx)
+
+    # determine if the projections should be applied to the right or left
+    print("Deriving equation:", f"{proj_eqname} = <{L}| {ops} |{R}>", flush=True)
+
+    pq.set_left_operators( L)
+    pq.set_right_operators(R)
+
+    for j, op in enumerate(ops):
+        if T is None:
+            pq.add_operator(coeffs[j], op)
+        else:
+            pq.add_st_operator(coeffs[j], op, T)
+    pq.simplify()
+
+    if spin_block:
+        block_by_spin(pq, proj_eqname, L + R + T + ops, eqs, idx)
+    else:
+        eqs[proj_eqname] = pq.clone()
+        # print the fully contracted strings
+        print(f"Equation {proj_eqname}:", flush=True)
+        terms = pq.strings()
+        terms = contracted_strings_to_tensor_terms(terms)
+        for term in terms:
+            print(f"# {term}", flush=True)
+            if idx==None:
+                print("# {}".format(term.einsum_string(update_val=proj_eqname)), flush=True)
+            else:
+                print("# {}".format(term.einsum_string(update_val=proj_eqname,output_variables=idx)), flush=True)
+    del pq
+
+def main():
+    """
+    Main function to derive and simplify equations using pdaggerq library.
+    """
+
+    # Operators and their coefficients
+    ops = [['w0'], ['d+'], ['d-'], ['f'], ['v']]
+    coeffs = [1.0, -1.0, -1.0, 1.0, 1.0]
+
+    # Coherent state operators and their coefficients
+    c_ops = [['B+'], ['B-']]
+    c_coeffs = [1.0, 1.0]
+
+    # T-operators (assumes T1 transformed integrals)
+    T = ['t2', 't0,1', 't1,1', 't2,1']
+
+    # Projection operators for different equations
+    proj = {
+        "energy": [['1']],                       # ground state energy
+        "rt1": [['e1(i,a)']],                    # singles residual
+        "rt2": [['e2(i,j,b,a)']],                # doubles residual
+
+        "rt0_1": [['B-']],                       # ground state + hw
+        "rt1_1": [['B-', 'e1(i,a)']],            # singles residual + hw
+        "rt2_1": [['B-', 'e2(i,j,b,a)']],        # doubles residual + hw
+    }
+
+    # Dictionary to store the derived equations
+    eqs = {}
+
+    for proj_eqname, P in proj.items():
+        # residual equations
+        derive_equation(eqs, proj_eqname, ops, coeffs, L=P, T=T, spin_block=True)
+        derive_equation(eqs, "c" + proj_eqname, c_ops, c_coeffs, L=P, T=T, spin_block=True)
+        print()
+
+def get_spin_labels(ops):
+    """
+    Get spin labels for the given operators.
+
+    Args:
+        ops (list): List of operators.
+
+    Returns:
+        dict: Dictionary mapping spin types to label-spin mappings.
+    """
+    spin_map = {}
+    labels = set()
+    found = False
+
+    # find all labels in the operators
+    for op in ops:
+        for subop in op:
+            # no labels in the operator
+            if "(" not in subop:
+                continue
+
+            # extract labels from the operator
+            subop_labels = subop[subop.find("(") + 1:subop.find(")")].split(",")
+            for label in subop_labels:
+                # add the label to the set
+                labels.add(label)
+                found = True
+
+    # no labels found in the operators; no spin blocking
+    if not found:
+        return {"": {}}
+
+    # sort the labels and create spin types based on the number of unique labels
+    labels = sorted(labels)
+    spin_types = ["aaaa", "abab", "bbbb"] if len(labels) == 4 else (
+        ["aaa", "abb", "aba", "bbb"] if len(labels) == 3 else (
+            ["aa", "bb"] if len(labels) == 2 else (
+                ["a", "b"] if len(labels) == 1 else []
+            )
+        )
+    )
+
+    # create a mapping of labels to spins for each spin type
+    for spin in spin_types:
+        if len(labels) != len(spin):
+            continue
+        label_to_spin = {label: spin[i] for i, label in enumerate(labels)}
+        spin_map[spin] = label_to_spin
+
+    return spin_map
+
+def block_by_spin(pq, eqname, ops, eqs, idx=None):
+    """
+    Block the equation by spin and store the result in the equations dictionary.
+
+    Args:
+        pq (pq_helper): pdaggerq helper object.
+        eqname (str): Name of the equation.
+        ops (list): List of operators.
+        eqs (dict): Dictionary to store the derived equations.
+    """
+    spin_map = get_spin_labels(ops)
+
+    # print the blocking by spin
+    print("Blocking by spin:", flush=True)
+    for spins, label_to_spin in spin_map.items():
+        print(f"{spins} ->", ", ".join(f"{label} -> {spin}" for label, spin in label_to_spin.items()), flush=True)
+    print()
+
+    # create equations for each spin block
+    for spins, label_to_spin in spin_map.items():
+        spin_eqname = eqname if spins == "" else eqname + "_" + spins
+        pq.block_by_spin(label_to_spin)
+
+        # store the equation in the dictionary
+        eqs[spin_eqname] = pq.clone()
+
+        # print the fully contracted strings
+        print(f"Equation {spin_eqname}:", flush=True)
+        terms = pq.strings()
+        terms = contracted_strings_to_tensor_terms(terms)
+        for term in terms:
+            print(f"# {term}", flush=True)
+            if idx == None:
+                print("# {}".format(term.einsum_string(update_val=spin_eqname)), flush=True)
+            else:
+                print("# {}".format(term.einsum_string(update_val=spin_eqname, output_variables=idx)), flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/examples/qed_ccsd_22_codegen.py
+++ b/examples/qed_ccsd_22_codegen.py
@@ -1,0 +1,202 @@
+import pdaggerq
+from pdaggerq.parser import contracted_strings_to_tensor_terms
+import re
+
+def derive_equation(eqs, proj_eqname, ops, coeffs, L = None, R = None, T = None, spin_block = False):
+    """
+    Derive and simplify the equation for the given projection operator.
+
+    Args:
+        proj_eqname (str): Name of the projection equation.
+        P (list): Projection operators.
+        ops (list): Operators.
+        coeffs (list): Coefficients for the operators.
+        T (list): T-operators.
+        eqs (dict): Dictionary to store the derived equations.
+    """
+    pq = pdaggerq.pq_helper("fermi")
+
+    if L is None:
+        L = [['1']]
+    if R is None:
+        R = [['1']]
+
+    # indices pattern looks like '[...]([a-zA-Z],...,[a-zA-Z])'
+    # with ChatGPT's help:
+    # (?<=\() : Positive lookbehind to match ( but not include it in the result.
+    # [^)]+   : Match one or more characters that are not a closing parenthesis ).
+    # (?=\))  : Positive lookahead to match ) but not include it in the result.
+    idx_pattern  = re.compile('(?<=\()[^)]+(?=\))')
+
+    idx = idx_pattern.findall(L[0][-1])
+    if len(idx)==0:
+        idx = None
+    else:
+        tmp = idx[0].split(',')
+        idx = []
+        for i in range(len(tmp)//2):
+            idx.append(tmp[-1-i])
+        for i in range(len(tmp)//2):
+            idx.append(tmp[i])
+
+        idx = tuple(idx)
+
+    # determine if the projections should be applied to the right or left
+    print("Deriving equation:", f"{proj_eqname} = <{L}| {ops} |{R}>", flush=True)
+
+    pq.set_left_operators( L)
+    pq.set_right_operators(R)
+
+    for j, op in enumerate(ops):
+        if T is None:
+            pq.add_operator(coeffs[j], op)
+        else:
+            pq.add_st_operator(coeffs[j], op, T)
+    pq.simplify()
+
+    if spin_block:
+        block_by_spin(pq, proj_eqname, L + R + T + ops, eqs, idx)
+    else:
+        eqs[proj_eqname] = pq.clone()
+        # print the fully contracted strings
+        print(f"Equation {proj_eqname}:", flush=True)
+        terms = pq.strings()
+        terms = contracted_strings_to_tensor_terms(terms)
+        for term in terms:
+            print(f"# {term}", flush=True)
+            if idx==None:
+                print("# {}".format(term.einsum_string(update_val=proj_eqname)), flush=True)
+            else:
+                print("# {}".format(term.einsum_string(update_val=proj_eqname,output_variables=idx)), flush=True)
+    del pq
+
+def main():
+    """
+    Main function to derive and simplify equations using pdaggerq library.
+    """
+
+    # Operators and their coefficients
+    ops = [['w0'], ['d+'], ['d-'], ['f'], ['v']]
+    coeffs = [1.0, -1.0, -1.0, 1.0, 1.0]
+
+    # Coherent state operators and their coefficients
+    c_ops = [['B+'], ['B-']]
+    c_coeffs = [1.0, 1.0]
+
+    # T-operators (assumes T1 transformed integrals)
+    T = ['t2', 't0,1', 't1,1', 't2,1', 't0,2', 't1,2', 't2,2']
+
+    # Projection operators for different equations
+    proj = {
+        "energy": [['1']],                       # ground state energy
+        "rt1": [['e1(i,a)']],                    # singles residual
+        "rt2": [['e2(i,j,b,a)']],                # doubles residual
+
+        "rt0_1": [['B-']],                       # ground state + hw
+        "rt1_1": [['B-', 'e1(i,a)']],            # singles residual + hw
+        "rt2_1": [['B-', 'e2(i,j,b,a)']],        # doubles residual + hw
+
+        "rt0_2": [['B-', 'B-']],                 # ground state + 2hw
+        "rt1_2": [['B-', 'B-', 'e1(i,a)']],      # singles residual + 2hw
+        "rt2_2": [['B-', 'B-', 'e2(i,j,b,a)']],  # doubles residual + 2hw
+    }
+
+    # Dictionary to store the derived equations
+    eqs = {}
+
+    for proj_eqname, P in proj.items():
+        # residual equations
+        derive_equation(eqs, proj_eqname, ops, coeffs, L=P, T=T, spin_block=True)
+        derive_equation(eqs, "c" + proj_eqname, c_ops, c_coeffs, L=P, T=T, spin_block=True)
+        print()
+
+def get_spin_labels(ops):
+    """
+    Get spin labels for the given operators.
+
+    Args:
+        ops (list): List of operators.
+
+    Returns:
+        dict: Dictionary mapping spin types to label-spin mappings.
+    """
+    spin_map = {}
+    labels = set()
+    found = False
+
+    # find all labels in the operators
+    for op in ops:
+        for subop in op:
+            # no labels in the operator
+            if "(" not in subop:
+                continue
+
+            # extract labels from the operator
+            subop_labels = subop[subop.find("(") + 1:subop.find(")")].split(",")
+            for label in subop_labels:
+                # add the label to the set
+                labels.add(label)
+                found = True
+
+    # no labels found in the operators; no spin blocking
+    if not found:
+        return {"": {}}
+
+    # sort the labels and create spin types based on the number of unique labels
+    labels = sorted(labels)
+    spin_types = ["aaaa", "abab", "bbbb"] if len(labels) == 4 else (
+        ["aaa", "abb", "aba", "bbb"] if len(labels) == 3 else (
+            ["aa", "bb"] if len(labels) == 2 else (
+                ["a", "b"] if len(labels) == 1 else []
+            )
+        )
+    )
+
+    # create a mapping of labels to spins for each spin type
+    for spin in spin_types:
+        if len(labels) != len(spin):
+            continue
+        label_to_spin = {label: spin[i] for i, label in enumerate(labels)}
+        spin_map[spin] = label_to_spin
+
+    return spin_map
+
+def block_by_spin(pq, eqname, ops, eqs, idx=None):
+    """
+    Block the equation by spin and store the result in the equations dictionary.
+
+    Args:
+        pq (pq_helper): pdaggerq helper object.
+        eqname (str): Name of the equation.
+        ops (list): List of operators.
+        eqs (dict): Dictionary to store the derived equations.
+    """
+    spin_map = get_spin_labels(ops)
+
+    # print the blocking by spin
+    print("Blocking by spin:", flush=True)
+    for spins, label_to_spin in spin_map.items():
+        print(f"{spins} ->", ", ".join(f"{label} -> {spin}" for label, spin in label_to_spin.items()), flush=True)
+    print()
+
+    # create equations for each spin block
+    for spins, label_to_spin in spin_map.items():
+        spin_eqname = eqname if spins == "" else eqname + "_" + spins
+        pq.block_by_spin(label_to_spin)
+
+        # store the equation in the dictionary
+        eqs[spin_eqname] = pq.clone()
+
+        # print the fully contracted strings
+        print(f"Equation {spin_eqname}:", flush=True)
+        terms = pq.strings()
+        terms = contracted_strings_to_tensor_terms(terms)
+        for term in terms:
+            print(f"# {term}", flush=True)
+            if idx == None:
+                print("# {}".format(term.einsum_string(update_val=spin_eqname)), flush=True)
+            else:
+                print("# {}".format(term.einsum_string(update_val=spin_eqname, output_variables=idx)), flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/pdaggerq/algebra.py
+++ b/pdaggerq/algebra.py
@@ -28,6 +28,12 @@ from pdaggerq.config import *
 # these are integrals, RDMs, etc. that require explicit slicing in einsum
 tensors_with_slices = ['h', 'g', 'f', 'kd', 'd1', 'd2', 'd3', 'd4', 'dipole']
 
+# these are amplitudes, having fixed shape and do not require explicit slicing
+tensors_amps  = ['w0']
+tensors_amps += ['t'+str(i) for i in range(0,5)]
+tensors_amps += ['r'+str(i) for i in range(0,5)]
+tensors_amps += ['l'+str(i) for i in range(0,5)]
+
 class Index:
 
     def __init__(self, name: str, support: str):
@@ -310,14 +316,6 @@ class TensorTerm:
             occ_char = 'o'
         if virt_char is None:
             virt_char = 'v'  # v = slice(nocc, None)
-
-
-        # these are amplitudes, having fixed shape and do not require explicit slicing
-        tensors_amps  = ['w0']
-        tensors_amps += ['t'+str(i) for i in range(0,5)]
-        tensors_amps += ['r'+str(i) for i in range(0,5)]
-        tensors_amps += ['l'+str(i) for i in range(0,5)]
-
         for bt in self.base_terms:
             tensor_index_ranges = [] # 'o', 'v', or ':'
             # parse indices and process them
@@ -448,54 +446,29 @@ class TensorTerm:
             teinsum_string += " + ".join(update_val_line)
         return teinsum_string
 
-class Right0amps(BaseTerm):
+class Rank0Amps(BaseTerm):
 
-    def __init__(self, *, indices=(), name='r0', spin='', active='', boson=''):
+    def __init__(self, *, indices=(), name='t0', spin='', active='', boson=''):
         super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
-class Right1amps(BaseTerm):
+class Rank1Amps(BaseTerm):
 
-    def __init__(self, *, indices=Tuple[Index, ...], name='r1', spin='', active='', boson=''):
+    def __init__(self, *, indices=(), name='t1', spin='', active='', boson=''):
         super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
-class Right2amps(BaseTerm):
+class Rank2Amps(BaseTerm):
 
-    def __init__(self, *, indices=Tuple[Index, ...], name='r2', spin='', active='', boson=''):
+    def __init__(self, *, indices=(), name='t2', spin='', active='', boson=''):
         super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
-class Right3amps(BaseTerm):
+class Rank3Amps(BaseTerm):
 
-    def __init__(self, *, indices=Tuple[Index, ...], name='r3', spin='', active='', boson=''):
+    def __init__(self, *, indices=(), name='t3', spin='', active='', boson=''):
         super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
-class Right4amps(BaseTerm):
+class Rank4Amps(BaseTerm):
 
-    def __init__(self, *, indices=Tuple[Index, ...], name='r4', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class Left0amps(BaseTerm):
-
-    def __init__(self, *, indices=(), name='l0', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class Left1amps(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='l1', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class Left2amps(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='l2', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class Left3amps(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='l3', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class Left4amps(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='l4', spin='', active='', boson=''):
+    def __init__(self, *, indices=(), name='t4', spin='', active='', boson=''):
         super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
 class D1(BaseTerm):
@@ -518,41 +491,13 @@ class D4(BaseTerm):
     def __init__(self, *, indices=Tuple[Index, ...], name='d4', spin='', active='', boson=''):
         super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
-class T0amps(BaseTerm):
-
-    def __init__(self, *, indices=(), name='t0', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class T1amps(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='t1', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class T2amps(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='t2', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class T3amps(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='t3', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class T4amps(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='t4', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
 class OneBody(BaseTerm):
 
     def __init__(self, *, indices=Tuple[Index, ...], name='h', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class FockMat(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='f', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
+        if name=='d+' or name=='d-':
+            super().__init__(indices=indices, name='dipole', spin=spin, active=active, boson=boson)
+        else:
+            super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
 class TwoBody(BaseTerm):
 
@@ -565,21 +510,11 @@ class TwoBody(BaseTerm):
 
 class Delta(BaseTerm):
 
-    def __init__(self, *, indices=Tuple[Index, ...], name='kd', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
+    def __init__(self, *, indices=Tuple[Index, ...], name='', spin='', active='', boson=''):
+        super().__init__(indices=indices, name='kd', spin=spin, active=active, boson=boson)
 
     def __repr__(self):
         return "d({},{})".format(self.indices[0], self.indices[1])
-
-class Dipole(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='dipole', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
-
-class BosonDiagonal(BaseTerm):
-
-    def __init__(self, *, indices=Tuple[Index, ...], name='w0', spin='', active='', boson=''):
-        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
 class ContractionPermuter(TensorTermAction):
 

--- a/pdaggerq/algebra.py
+++ b/pdaggerq/algebra.py
@@ -26,7 +26,7 @@ import numpy as np
 from pdaggerq.config import *
 
 # these are integrals, RDMs, etc. that require explicit slicing in einsum
-tensors_with_slices = ['h', 'g', 'f', 'kd', 'd1', 'd2', 'd3', 'd4']
+tensors_with_slices = ['h', 'g', 'f', 'kd', 'd1', 'd2', 'd3', 'd4', 'dipole']
 
 class Index:
 
@@ -313,7 +313,8 @@ class TensorTerm:
 
 
         # these are amplitudes, having fixed shape and do not require explicit slicing
-        tensors_amps  = ['t'+str(i) for i in range(1,5)]
+        tensors_amps  = ['w0']
+        tensors_amps += ['t'+str(i) for i in range(0,5)]
         tensors_amps += ['r'+str(i) for i in range(0,5)]
         tensors_amps += ['l'+str(i) for i in range(0,5)]
 
@@ -517,6 +518,11 @@ class D4(BaseTerm):
     def __init__(self, *, indices=Tuple[Index, ...], name='d4', spin='', active='', boson=''):
         super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
+class T0amps(BaseTerm):
+
+    def __init__(self, *, indices=(), name='t0', spin='', active='', boson=''):
+        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
+
 class T1amps(BaseTerm):
 
     def __init__(self, *, indices=Tuple[Index, ...], name='t1', spin='', active='', boson=''):
@@ -568,6 +574,11 @@ class Delta(BaseTerm):
 class Dipole(BaseTerm):
 
     def __init__(self, *, indices=Tuple[Index, ...], name='dipole', spin='', active='', boson=''):
+        super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
+
+class BosonDiagonal(BaseTerm):
+
+    def __init__(self, *, indices=Tuple[Index, ...], name='w0', spin='', active='', boson=''):
         super().__init__(indices=indices, name=name, spin=spin, active=active, boson=boson)
 
 class ContractionPermuter(TensorTermAction):

--- a/pdaggerq/parser.py
+++ b/pdaggerq/parser.py
@@ -15,14 +15,14 @@
 #   limitations under the License.
 
 import re
-from pdaggerq.algebra import (OneBody, TwoBody, T1amps, T2amps, T3amps, T4amps,
-                              Index, TensorTerm, D1, D2, D3, D4,
-                              Delta, Left0amps, Left1amps,
-                              Left2amps, Left3amps, Left4amps, Right0amps,
-                              Right1amps, Right2amps, Right3amps, Right4amps,
-                              FockMat, Dipole, BaseTerm, ContractionPermuter,
-                              ContractionPairPermuter3, ContractionPairPermuter6,
-                              ContractionPairPermuter2, TensorTermAction, )
+from pdaggerq.algebra import (BaseTerm, Index, TensorTerm, TensorTermAction,
+                              OneBody, TwoBody, FockMat, Delta, Dipole,
+                              D1, D2, D3, D4, BosonDiagonal,
+                              T0amps, T1amps, T2amps, T3amps, T4amps,
+                              Left0amps, Left1amps, Left2amps, Left3amps, Left4amps,
+                              Right0amps, Right1amps, Right2amps, Right3amps, Right4amps,
+                              ContractionPermuter, ContractionPairPermuter2,
+                              ContractionPairPermuter3, ContractionPairPermuter6)
 from pdaggerq.config import OCC_INDICES, VIRT_INDICES
 
 
@@ -36,10 +36,12 @@ def string_to_baseterm(term_string, occ_idx=OCC_INDICES, virt_idx=VIRT_INDICES):
         'd' : Delta,
         'd+' : Dipole,
         'd-' : Dipole,
+        'w0' : BosonDiagonal,
         'd1' : D1,
         'd2' : D2,
         'd3' : D3,
         'd4' : D4,
+        't0' : T0amps,
         't1' : T1amps,
         't2' : T2amps,
         't3' : T3amps,

--- a/pdaggerq/parser.py
+++ b/pdaggerq/parser.py
@@ -16,11 +16,9 @@
 
 import re
 from pdaggerq.algebra import (BaseTerm, Index, TensorTerm, TensorTermAction,
-                              OneBody, TwoBody, FockMat, Delta, Dipole,
-                              D1, D2, D3, D4, BosonDiagonal,
-                              T0amps, T1amps, T2amps, T3amps, T4amps,
-                              Left0amps, Left1amps, Left2amps, Left3amps, Left4amps,
-                              Right0amps, Right1amps, Right2amps, Right3amps, Right4amps,
+                              OneBody, TwoBody, Delta,
+                              D1, D2, D3, D4,
+                              Rank0Amps, Rank1Amps, Rank2Amps, Rank3Amps, Rank4Amps,
                               ContractionPermuter, ContractionPairPermuter2,
                               ContractionPairPermuter3, ContractionPairPermuter6)
 from pdaggerq.config import OCC_INDICES, VIRT_INDICES
@@ -32,34 +30,34 @@ def string_to_baseterm(term_string, occ_idx=OCC_INDICES, virt_idx=VIRT_INDICES):
     tensor_map = {
         'h' : OneBody,
         'g' : TwoBody,
-        'f' : FockMat,
+        'f' : OneBody,
         'd' : Delta,
-        'd+' : Dipole,
-        'd-' : Dipole,
-        'w0' : BosonDiagonal,
+        'd+' : OneBody,
+        'd-' : OneBody,
+        'w0' : Rank0Amps,
         'd1' : D1,
         'd2' : D2,
         'd3' : D3,
         'd4' : D4,
-        't0' : T0amps,
-        't1' : T1amps,
-        't2' : T2amps,
-        't3' : T3amps,
-        't4' : T4amps,
-        'r0' : Right0amps,
-        'r1' : Right1amps,
-        'r2' : Right2amps,
-        'r3' : Right3amps,
-        'r4' : Right4amps,
-        'l0' : Left0amps,
-        'l1' : Left1amps,
-        'l2' : Left2amps,
-        'l3' : Left3amps,
-        'l4' : Left4amps,
+        't0' : Rank0Amps,
+        't1' : Rank1Amps,
+        't2' : Rank2Amps,
+        't3' : Rank3Amps,
+        't4' : Rank4Amps,
+        'r0' : Rank0Amps,
+        'r1' : Rank1Amps,
+        'r2' : Rank2Amps,
+        'r3' : Rank3Amps,
+        'r4' : Rank4Amps,
+        'l0' : Rank0Amps,
+        'l1' : Rank1Amps,
+        'l2' : Rank2Amps,
+        'l3' : Rank3Amps,
+        'l4' : Rank4Amps,
     }
     # tensor action has different constructor, so put new ones here
     tensor_action_map = {
-        'p' : ContractionPermuter,
+        'p'   : ContractionPermuter,
         'pp2' : ContractionPairPermuter2,
         'pp3' : ContractionPairPermuter3,
         'pp6' : ContractionPairPermuter6
@@ -137,7 +135,7 @@ def string_to_baseterm(term_string, occ_idx=OCC_INDICES, virt_idx=VIRT_INDICES):
         # make operator label lowercase from this point on
         term_string = term_string.lower()
         if term_string in tensor_map.keys():
-            return tensor_map[term_string](indices=tuple(idx), spin=spin, active=active, boson=boson)
+            return tensor_map[term_string](indices=tuple(idx), name=term_string, spin=spin, active=active, boson=boson)
         elif term_string in tensor_action_map.keys():
             return tensor_action_map[term_string](indices=tuple(idx), spin=spin)
         else:


### PR DESCRIPTION
This PR fixes a few small bugs in the python-side parser. Furthermore, it adds `w0` amplitude for cavity QED code generations.

The `algebra.py` file is now simplified, but different rank tensors and matrices are still kept separate for future use cases.

There are two new examples `qed_ccsd_21_codegen.py` and `qed_ccsd_22_codegen.py` that should work correctly with the python-side parser.