### PR TITLE
refactoring add_operator_product

### DIFF
--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -133,7 +133,7 @@ void export_pq_helper(py::module& m) {
         .def("add_quadruple_commutator", &pq_helper::add_quadruple_commutator)
         .def("add_quintuple_commutator", &pq_helper::add_quintuple_commutator)
         .def("add_hextuple_commutator", &pq_helper::add_hextuple_commutator)
-        .def("add_operator_product", &pq_helper::add_operator_product);
+        .def("add_operator_product", &pq_helper::py_add_operator_product);
 
     py::class_<pdaggerq::pq_operator_terms>(m, "pq_operator_terms")
         .def(py::init<double, std::vector<std::string>>())
@@ -296,9 +296,10 @@ void pq_helper::add_anticommutator(double factor,
                                    const std::vector<std::string> &op0,
                                    const std::vector<std::string> &op1){
 
-    add_operator_product(factor, concatinate_operators({op0, op1}) );
-    add_operator_product(factor, concatinate_operators({op1, op0}) );
-
+    std::vector<pq_operator_terms> ops;
+    ops.push_back(pq_operator_terms( factor, concatinate_operators({op0, op1}) ));
+    ops.push_back(pq_operator_terms( factor, concatinate_operators({op1, op0}) ));
+    process_operator_products(ops);
 }
 
 void pq_helper::add_commutator(double factor,
@@ -306,9 +307,7 @@ void pq_helper::add_commutator(double factor,
                                const std::vector<std::string> &op1){
 
     std::vector<pq_operator_terms> ops = get_commutator_terms(factor, op0, op1);
-    for (auto op : ops){
-        add_operator_product(op.factor, op.operators);
-    }
+    process_operator_products(ops);
 }
 
 std::vector<pq_operator_terms> pq_helper::get_commutator_terms(double factor,
@@ -329,9 +328,7 @@ void pq_helper::add_double_commutator(double factor,
                                       const std::vector<std::string> &op2){
 
     std::vector<pq_operator_terms> ops = get_double_commutator_terms(factor, op0, op1, op2);
-    for (auto op : ops){
-        add_operator_product(op.factor, op.operators);
-    }
+    process_operator_products(ops);
 }
 
 std::vector<pq_operator_terms> pq_helper::get_double_commutator_terms(double factor,
@@ -356,9 +353,7 @@ void pq_helper::add_triple_commutator(double factor,
                                         const std::vector<std::string> &op3){
 
     std::vector<pq_operator_terms> ops = get_triple_commutator_terms(factor, op0, op1, op2, op3);
-    for (auto op : ops){
-        add_operator_product(op.factor, op.operators);
-    }
+    process_operator_products(ops);
 }
 
 std::vector<pq_operator_terms> pq_helper::get_triple_commutator_terms(double factor,
@@ -389,9 +384,7 @@ void pq_helper::add_quadruple_commutator(double factor,
                                          const std::vector<std::string> &op4){
 
     std::vector<pq_operator_terms> ops = get_quadruple_commutator_terms(factor, op0, op1, op2, op3, op4);
-    for (auto op : ops){
-        add_operator_product(op.factor, op.operators);
-    }
+    process_operator_products(ops);
 }
 
 std::vector<pq_operator_terms> pq_helper::get_quadruple_commutator_terms(double factor,
@@ -478,9 +471,7 @@ void pq_helper::add_quintuple_commutator(double factor,
                                          const std::vector<std::string> &op5){
 
     std::vector<pq_operator_terms> ops = get_quintuple_commutator_terms(factor, op0, op1, op2, op3, op4, op5);
-    for (auto op : ops){
-        add_operator_product(op.factor, op.operators);
-    }
+    process_operator_products(ops);
 }
 
 std::vector<pq_operator_terms> pq_helper::get_hextuple_commutator_terms(double factor,
@@ -572,21 +563,30 @@ void pq_helper::add_hextuple_commutator(double factor,
                                         const std::vector<std::string> &op6){
 
     std::vector<pq_operator_terms> ops = get_hextuple_commutator_terms(factor, op0, op1, op2, op3, op4, op5, op6);
+    process_operator_products(ops);
+}
+
+void pq_helper::process_operator_products(std::vector<pq_operator_terms> ops) {
     for (auto op : ops){
         add_operator_product(op.factor, op.operators);
     }
 }
 
+// wrapper for python calling add_operator_product directly
+void pq_helper::py_add_operator_product(double factor, std::vector<std::string>  in){
+
+    std::vector<pq_operator_terms> ops = {pq_operator_terms( factor, in)};
+    process_operator_products(ops);
+
+}
+
 // add a string of operators
 void pq_helper::add_operator_product(double factor, std::vector<std::string>  in){
 
-    // check if there is a fluctuation potential operator 
-    // that needs to be split into multiple terms
+    // check if there is a fluctuation potential operator that needs to be split into multiple terms
 
-    // left operators 
-    // this is not handled correctly now that left operators can be sums of products of operators ... just exit with an error
+    // 'v' cannot appear in left operators ... exit with error
     for (std::vector<std::string> & left_operator : left_operators) {
-        std::vector<std::string> tmp;
         for (const std::string & op : left_operator) {
             if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
 
@@ -594,22 +594,12 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
                 printf("    error: the fluctuation potential cannot appear in operators defining the bra state\n");
                 printf("\n");
                 exit(1);
-
-            }else {
-                tmp.push_back(op);
             }
         }
-        left_operator.clear();
-        for (const auto & op : tmp) {
-            left_operator.push_back(op);
-        }
-        tmp.clear();
     }
     
-    // right operators 
-    // this is not handled correectly now that right operators can be sums of products of operators ... just exit with an error
+    // 'v' cannot appear in right operators ... exit with error
     for (std::vector<std::string> & right_operator : right_operators) {
-        std::vector<std::string> tmp;
         for (const std::string & op : right_operator) {
             if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
 
@@ -617,16 +607,8 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
                 printf("    error: the fluctuation potential cannot appear in operators defining the ket state\n");
                 printf("\n");
                 exit(1);
-
-            }else {
-                tmp.push_back(op);
             }
         }
-        right_operator.clear();
-        for (const std::string & op : tmp) {
-            right_operator.push_back(op);
-        }
-        tmp.clear();
     }
 
     int count = 0;
@@ -697,6 +679,8 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
         }
         return;
     }
+
+    // check if there is a fock operator that should be treated in normal order
 
     count = 0;
     bool found_f = false;

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -24,6 +24,8 @@
 #ifndef _python_api2_h_
 #define _python_api2_h_
 
+#include <tuple>
+#include <utility>
 #include <memory>
 #include <vector>
 #include <iostream>
@@ -567,6 +569,33 @@ void pq_helper::add_hextuple_commutator(double factor,
 }
 
 void pq_helper::process_operator_products(std::vector<pq_operator_terms> ops) {
+
+    // 'v' = 'j1' + 'j2'
+    bool done_processing = false;
+    std::vector<pq_operator_terms> new_ops;
+    do {
+        std::tie(done_processing, new_ops) = process_fluctuation_potential(ops);
+        ops = new_ops;
+    }while(!done_processing);
+
+    // 't1' = 't1e' or 't1' = 't1e' - 't1d', etc.
+    done_processing = false;
+    do {
+        std::tie(done_processing, new_ops) = process_cluster_amplitudes(ops);
+        ops = new_ops;
+    }while(!done_processing);
+
+    if (is_hamiltonian_normal_ordered) {
+        // TODO: normal order 'j2' and drop 'j1' 
+        // TODO: normal order 'f' 
+        printf("\n");
+        printf("    error: the normal ordered hamiltonian operators are broken\n");
+        printf("\n");
+        exit(1);
+    }
+
+    // TODO: normal order the entire argument, if desired
+
     for (auto op : ops){
         add_operator_product(op.factor, op.operators);
     }
@@ -580,56 +609,62 @@ void pq_helper::py_add_operator_product(double factor, std::vector<std::string> 
 
 }
 
-// add a string of operators
-void pq_helper::add_operator_product(double factor, std::vector<std::string>  in){
+// check if there are fluctuation potential operators that needs to be split into multiple terms
+std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_fluctuation_potential(std::vector<pq_operator_terms> ops_in){
 
-    // check if there is a fluctuation potential operator that needs to be split into multiple terms
+    std::vector<pq_operator_terms> ops_out;
 
-    // 'v' cannot appear in left operators ... exit with error
-    for (std::vector<std::string> & left_operator : left_operators) {
-        for (const std::string & op : left_operator) {
-            if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
+    bool done_processing = true;
 
-                printf("\n");
-                printf("    error: the fluctuation potential cannot appear in operators defining the bra state\n");
-                printf("\n");
-                exit(1);
+    for (auto op: ops_in) {
+        double factor = op.factor;
+        std::vector<std::string> in = op.operators;
+
+        // 'v' cannot appear in left operators ... exit with error
+        for (std::vector<std::string> & left_operator : left_operators) {
+            for (const std::string & op : left_operator) {
+                if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
+
+                    printf("\n");
+                    printf("    error: the fluctuation potential cannot appear in operators defining the bra state\n");
+                    printf("\n");
+                    exit(1);
+                }
             }
         }
-    }
-    
-    // 'v' cannot appear in right operators ... exit with error
-    for (std::vector<std::string> & right_operator : right_operators) {
-        for (const std::string & op : right_operator) {
-            if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
+        
+        // 'v' cannot appear in right operators ... exit with error
+        for (std::vector<std::string> & right_operator : right_operators) {
+            for (const std::string & op : right_operator) {
+                if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
 
-                printf("\n");
-                printf("    error: the fluctuation potential cannot appear in operators defining the ket state\n");
-                printf("\n");
-                exit(1);
+                    printf("\n");
+                    printf("    error: the fluctuation potential cannot appear in operators defining the ket state\n");
+                    printf("\n");
+                    exit(1);
+                }
             }
         }
-    }
 
-    int count = 0;
-    bool found_v = false;
-    std::vector<std::string> tmp_in;
-    for (const std::string & op : in) {
-        if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
-            found_v = true;
-            break;
-        }else {
-            tmp_in.push_back(op);
-            count++;
+        int count = 0;
+        bool found_v = false;
+        std::vector<std::string> tmp_in;
+        for (const std::string & op : in) {
+            if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
+                found_v = true;
+                break;
+            }else {
+                tmp_in.push_back(op);
+                count++;
+            }
         }
-    }
-    if ( found_v ) {
+        if ( found_v ) {
+            done_processing = false;
 
-        // get bernoulli operator portions
-        std::string op_portions = get_operator_portions_as_string(in[count]);
+            // get bernoulli operator portions
+            std::string op_portions = get_operator_portions_as_string(in[count]);
 
-        if ( !is_hamiltonian_normal_ordered ) {
-            // term 1
+            // term 1 (j1)
             std::string v_type = "j1";
             if ( op_portions.length() > 0 ) { 
                 v_type += "{" + op_portions + "}";
@@ -642,9 +677,9 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
             for (const auto & op : tmp_in) {
                 in.push_back(op);
             }
-            add_operator_product(factor, in);
+            ops_out.push_back(pq_operator_terms(factor, in));
 
-            // term 2
+            // term 2 (j2)
             in.clear();
             for (int i = 0; i < count; i++) {
                 in.push_back(tmp_in[i]);
@@ -654,131 +689,97 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
             for (int i = count + 1; i < (int)tmp_in.size(); i++) {
                 in.push_back(tmp_in[i]);
             }
-            add_operator_product(factor, in);
+            ops_out.push_back(pq_operator_terms(factor, in));
+
         }else {
-            for (int label = 0; label < 16; label++) {
-                std::vector<std::string> my_in;
-                for (int i = 0; i < count; i++) {
-                    my_in.push_back(in[i]);
-                }
-                // only term 2 (16 times...)
-                std::string v_type = "j2" + std::to_string(label);
-                if ( op_portions.length() > 0 ) { 
-                    v_type += "{" + op_portions + "}";
-                }
-                my_in.push_back(v_type);
-                for (int i = count+1; i < (int)in.size(); i++) {
-                    my_in.push_back(in[i]);
-                }
-                in.clear();
-                for (const auto & op : my_in) {
-                    in.push_back(op);
-                }
-                add_operator_product(factor, in);
-            }
-        }
-        return;
-    }
-
-    // check if there is a fock operator that should be treated in normal order
-
-    count = 0;
-    bool found_f = false;
-    for (const std::string & op : in) {
-        if (op == "f" || op == "F") {
-            found_f = true;
-            break;
-        }else {
-            count++;
-        }
-    }
-    if ( found_f ) {
-        if ( !is_hamiltonian_normal_ordered ) {
-            // do nothing
-        }else {
-            // add each block of F separately, Fvv, Fvo, Fov, Foo
-            for (int label = 0; label < 4; label++) {
-                std::vector<std::string> my_in;
-                for (int i = 0; i < count; i++) {
-                    my_in.push_back(in[i]);
-                }
-                // 4 blocks
-                my_in.push_back('f' + std::to_string(label));
-                for (int i = count+1; i < (int)in.size(); i++) {
-                    my_in.push_back(in[i]);
-                }
-                in.clear();
-                for (const auto & op : my_in) {
-                    in.push_back(op);
-                }
-                add_operator_product(factor, in);
-            }
-            return;
+            ops_out.push_back(op);
         }
     }
 
-    // now check for t and add de-excitation operators if doing unitary cc
-    // first, if unitary cc, t can't show up in right or left operator lists (yet)
-    if ( is_unitary_cc ) {
-        for (size_t i = 0; i < left_operators.size(); i++) {
-            for (size_t j = 0; j < left_operators[i].size(); j++) {
-                if ( left_operators[i][j].substr(0,1) == "t" || left_operators[i][j].substr(0,1) == "T" ||
-                     left_operators[i][j].substr(0,2) == "t{" || left_operators[i][j].substr(0,2) == "T{" ){
+    return std::make_pair(done_processing, ops_out);
+}
 
-                    printf("\n");
-                    printf("    error: unitary cluster operators cannot appear in the bra state\n");
-                    printf("\n");
-                    exit(1);
+// check for t and add de-excitation operators if doing unitary cc
+std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_cluster_amplitudes(std::vector<pq_operator_terms> ops_in){
 
+    std::vector<pq_operator_terms> ops_out;
+
+    bool done_processing = true;
+
+    for (auto op: ops_in) {
+        double factor = op.factor;
+        std::vector<std::string> in = op.operators;
+
+        // first, if unitary cc, t can't show up in right or left operator lists (yet)
+        if ( is_unitary_cc ) {
+            for (size_t i = 0; i < left_operators.size(); i++) {
+                for (size_t j = 0; j < left_operators[i].size(); j++) {
+                    if ( left_operators[i][j].substr(0,1) == "t" || left_operators[i][j].substr(0,1) == "T" ||
+                         left_operators[i][j].substr(0,2) == "t{" || left_operators[i][j].substr(0,2) == "T{" ){
+
+                        printf("\n");
+                        printf("    error: unitary cluster operators cannot appear in the bra state\n");
+                        printf("\n");
+                        exit(1);
+
+                    }
+                }
+            }
+            for (size_t i = 0; i < right_operators.size(); i++) {
+                for (size_t j = 0; j < right_operators[i].size(); j++) {
+                    if ( right_operators[i][j].substr(0,1) == "t" || right_operators[i][j].substr(0,1) == "T" ||
+                         right_operators[i][j].substr(0,2) == "t{" || right_operators[i][j].substr(0,2) == "T{" ){
+
+                        printf("\n");
+                        printf("    error: unitary cluster operators cannot appear in the ket state\n");
+                        printf("\n");
+                        exit(1);
+
+                    }
                 }
             }
         }
-        for (size_t i = 0; i < right_operators.size(); i++) {
-            for (size_t j = 0; j < right_operators[i].size(); j++) {
-                if ( right_operators[i][j].substr(0,1) == "t" || right_operators[i][j].substr(0,1) == "T" ||
-                     right_operators[i][j].substr(0,2) == "t{" || right_operators[i][j].substr(0,2) == "T{" ){
 
-                    printf("\n");
-                    printf("    error: unitary cluster operators cannot appear in the ket state\n");
-                    printf("\n");
-                    exit(1);
-
+        // now either rename cluster operators or split them into two, depending on whether we're unitary or not
+        int count = 0;
+        bool found_t = false;
+        for (size_t i = 0; i < in.size(); i++) {
+            if ( in[i].substr(0,1) == "t" || in[i].substr(0,1) == "T" ) {
+                if ( in[i].substr(0,2) != "te" && in[i].substr(0,2) != "td" ) {
+                    found_t = true;
+                    break;
+                }else {
+                    count++;
                 }
-            }
-        }
-    }
-
-    // now either rename cluster operators or split them into two, depending on whether we're unitary or not
-    count = 0;
-    bool found_t = false;
-    for (size_t i = 0; i < in.size(); i++) {
-        if ( in[i].substr(0,1) == "t" || in[i].substr(0,1) == "T" ) {
-            if ( in[i].substr(0,2) != "te" && in[i].substr(0,2) != "td" ) {
-                found_t = true;
-                break;
             }else {
                 count++;
             }
+        }
+
+        if ( found_t ) {
+            done_processing = false;
+
+            // term 1 (excitation)
+
+            in[count].insert(1, "e", 1);
+            ops_out.push_back(pq_operator_terms(factor, in));
+
+            // term 2 (de-excitation)
+            if ( is_unitary_cc ) {
+
+                in[count][1] = 'd';
+                ops_out.push_back(pq_operator_terms(-factor, in));
+            }
         }else {
-            count++;
+            ops_out.push_back(op);
         }
     }
 
-    if ( found_t ) {
+    return std::make_pair(done_processing, ops_out);
+}
 
-        // term 1 (excitation)
-
-        in[count].insert(1, "e", 1);
-        add_operator_product(factor, in);
-
-        // term 2 (de-excitation)
-        if ( is_unitary_cc ) {
-
-            in[count][1] = 'd';
-            add_operator_product(-factor, in);
-        }
-        return;
-    }
+// add a string of operators
+void pq_helper::add_operator_product(double factor, std::vector<std::string>  in){
 
     // apply any extra operators on left or right:
     std::vector<std::string> save;
@@ -1660,10 +1661,8 @@ void pq_helper::add_st_operator(double factor,
                                 const std::vector<std::string> &ops,
                                 bool do_operators_commute = true){
 
-    std::vector<pq_operator_terms> st_terms = get_st_operator_terms(factor, targets, ops, do_operators_commute);
-    for (auto term : st_terms){
-        add_operator_product(term.factor, term.operators);
-    }
+    std::vector<pq_operator_terms> st_ops = get_st_operator_terms(factor, targets, ops, do_operators_commute);
+    process_operator_products(st_ops);
 }
 
 std::vector<pq_operator_terms> pq_helper::get_st_operator_terms(double factor, const std::vector<std::string> &targets,const std::vector<std::string> &ops, bool do_operators_commute = true){
@@ -1809,9 +1808,7 @@ void pq_helper::add_bernoulli_operator(double factor,
                                        const int max_order) {
 
     std::vector<pq_operator_terms> bernoulli_terms = get_bernoulli_operator_terms(factor, targets, ops, max_order);
-    for (auto term : bernoulli_terms){
-        add_operator_product(term.factor, term.operators);
-    }
+    process_operator_products(bernoulli_terms);
 }
 
 std::vector<pq_operator_terms> pq_helper::get_bernoulli_operator_terms(double factor, const std::vector<std::string> &targets,const std::vector<std::string> &ops, const int max_order) {

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -584,7 +584,7 @@ std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_fluctuation_po
         // 'v' cannot appear in left operators ... exit with error
         for (std::vector<std::string> & left_operator : left_operators) {
             for (const std::string & op : left_operator) {
-                if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
+                if (op.substr(0, 1) == "v" || op.substr(0, 1) == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
 
                     printf("\n");
                     printf("    error: the fluctuation potential cannot appear in operators defining the bra state\n");
@@ -597,7 +597,7 @@ std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_fluctuation_po
         // 'v' cannot appear in right operators ... exit with error
         for (std::vector<std::string> & right_operator : right_operators) {
             for (const std::string & op : right_operator) {
-                if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
+                if (op.substr(0, 1) == "v" || op.substr(0, 1) == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
 
                     printf("\n");
                     printf("    error: the fluctuation potential cannot appear in operators defining the ket state\n");
@@ -608,10 +608,15 @@ std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_fluctuation_po
         }
 
         int count = 0;
-        bool found_v = false;
+        bool found_v = false; // fluctuation potential
+        bool found_vn = false; // normal-ordered fluctuation potential
         std::vector<std::string> tmp_in;
         for (const std::string & op : in) {
-            if (op == "v" || op == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
+            if (op.substr(0, 1) == "v" || op.substr(0, 1) == "V" || op.substr(0, 2) == "v{" || op.substr(0, 2) == "V{") {
+                if (op.substr(1, 1) == "n" || op.substr(1, 1) == "N") {
+                    found_vn = true;
+                    break;
+                }
                 found_v = true;
                 break;
             }else {
@@ -619,44 +624,152 @@ std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_fluctuation_po
                 count++;
             }
         }
-        if ( found_v ) {
+        if ( found_v || found_vn ) {
             done_processing = false;
 
             // get bernoulli operator portions
             std::string op_portions = get_operator_portions_as_string(in[count]);
 
-            // term 1 (j1)
-            std::string v_type = "j1";
-            if ( op_portions.length() > 0 ) { 
-                v_type += "{" + op_portions + "}";
-            }
-            tmp_in.emplace_back(v_type);
-            for (int i = count+1; i < (int)in.size(); i++) {
-                tmp_in.push_back(in[i]);
-            }
-            in.clear();
-            for (const auto & op : tmp_in) {
-                in.push_back(op);
-            }
-            ops_out.push_back(pq_operator_terms(factor, in));
+            if ( found_v ) {
+                // term 1 (j1)
+                std::string v_type = "j1";
+                if ( op_portions.length() > 0 ) { 
+                    v_type += "{" + op_portions + "}";
+                }
+                tmp_in.emplace_back(v_type);
+                for (int i = count+1; i < (int)in.size(); i++) {
+                    tmp_in.push_back(in[i]);
+                }
+                in.clear();
+                for (const auto & op : tmp_in) {
+                    in.push_back(op);
+                }
+                ops_out.push_back(pq_operator_terms(factor, in));
 
-            // term 2 (j2)
-            in.clear();
-            for (int i = 0; i < count; i++) {
-                in.push_back(tmp_in[i]);
-            }
-            v_type[1] = '2';
-            in.emplace_back(v_type);
-            for (int i = count + 1; i < (int)tmp_in.size(); i++) {
-                in.push_back(tmp_in[i]);
-            }
-            ops_out.push_back(pq_operator_terms(factor, in));
+                // term 2 (j2)
+                in.clear();
+                for (int i = 0; i < count; i++) {
+                    in.push_back(tmp_in[i]);
+                }
+                v_type[1] = '2';
+                in.emplace_back(v_type);
+                for (int i = count + 1; i < (int)tmp_in.size(); i++) {
+                    in.push_back(tmp_in[i]);
+                }
+                ops_out.push_back(pq_operator_terms(factor, in));
+            }else {
 
+                for (int label = 0; label < 16; label++) {
+                    std::vector<std::string> my_in;
+                    for (int i = 0; i < count; i++) {
+                        my_in.push_back(in[i]);
+                    }
+                    // only term 2 (16 times...)
+                    std::string v_type = "jn" + std::to_string(label);
+                    if ( op_portions.length() > 0 ) { 
+                        v_type += "{" + op_portions + "}";
+                    }
+                    my_in.push_back(v_type);
+                    for (int i = count+1; i < (int)in.size(); i++) {
+                        my_in.push_back(in[i]);
+                    }
+                    in.clear();
+                    for (const auto & op : my_in) {
+                        in.push_back(op);
+                    }
+                    ops_out.push_back(pq_operator_terms(factor, in));
+                }
+            }
         }else {
             ops_out.push_back(op);
         }
     }
 
+    return std::make_pair(done_processing, ops_out);
+}
+
+// check if there are normal-ordered fock operators that needs to be split into multiple terms
+std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_fock_operator(std::vector<pq_operator_terms> ops_in){
+    std::vector<pq_operator_terms> ops_out;
+
+    bool done_processing = true;
+
+    for (auto op: ops_in) {
+        double factor = op.factor;
+        std::vector<std::string> in = op.operators;
+
+        // 'f' cannot appear in left operators ... exit with error
+        for (std::vector<std::string> & left_operator : left_operators) {
+            for (const std::string & op : left_operator) {
+                if (op.substr(0, 1) == "f" || op.substr(0, 1) == "F") {
+                    if (op.substr(1, 1) == "n" || op.substr(1, 1) == "N") {
+
+                        printf("\n");
+                        printf("    error: the normal-ordered fock operator cannot appear in operators defining the bra state\n");
+                        printf("\n");
+                        exit(1);
+                    }
+                }
+            }
+        }
+        
+        // 'f' cannot appear in right operators ... exit with error
+        for (std::vector<std::string> & right_operator : right_operators) {
+            for (const std::string & op : right_operator) {
+                if (op.substr(0, 1) == "f" || op.substr(0, 1) == "F") {
+                    if (op.substr(1, 1) == "n" || op.substr(1, 1) == "N") {
+
+                        printf("\n");
+                        printf("    error: the normal-ordered fock operator cannot appear in operators defining the ket state\n");
+                        printf("\n");
+                        exit(1);
+                    }
+                }
+            }
+        }
+
+        int count = 0;
+        bool found_fn = false; // normal-ordered fn potential
+        std::vector<std::string> tmp_in;
+        for (const std::string & op : in) {
+            if (op.substr(0, 1) == "f" || op.substr(0, 1) == "F") {
+                if (op.substr(1, 1) == "n" || op.substr(1, 1) == "N") {
+                    found_fn = true;
+                    break;
+                }else {
+                    tmp_in.push_back(op);
+                    count++;
+                }
+            }else {
+                tmp_in.push_back(op);
+                count++;
+            }
+        }
+        if ( found_fn ) {
+
+            done_processing = false;
+
+            // add each block of F separately, Fvv, Fvo, Fov, Foo
+            for (int label = 0; label < 4; label++) {
+                std::vector<std::string> my_in;
+                for (int i = 0; i < count; i++) {
+                    my_in.push_back(in[i]);
+                }
+                // 4 blocks
+                my_in.push_back('f' + std::to_string(label));
+                for (int i = count+1; i < (int)in.size(); i++) {
+                    my_in.push_back(in[i]);
+                }
+                in.clear();
+                for (const auto & op : my_in) {
+                    in.push_back(op);
+                }
+                ops_out.push_back(pq_operator_terms(factor, in));
+            }
+        }else {
+            ops_out.push_back(op);
+        }
+    }
     return std::make_pair(done_processing, ops_out);
 }
 
@@ -741,13 +854,20 @@ std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_cluster_amplit
 
 void pq_helper::process_operator_products(std::vector<pq_operator_terms> ops) {
 
-    bool done_processing = false;
     std::vector<pq_operator_terms> new_ops;
 
     // check for fluctuation potential because it should be split as
     // 'v' = 'j1' + 'j2'
+    bool done_processing = false;
     do {
         std::tie(done_processing, new_ops) = process_fluctuation_potential(ops);
+        ops = new_ops;
+    }while(!done_processing);
+
+    // check for normal-ordered fock operator because it should be split
+    done_processing = false;
+    do {
+        std::tie(done_processing, new_ops) = process_fock_operator(ops);
         ops = new_ops;
     }while(!done_processing);
 
@@ -790,7 +910,9 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
     int o_count_1 = 0;
     int v_count_1 = 0;
     std::vector<std::shared_ptr<pq_string>> center_strings = build_new_strings(1.0, in, o_count_1, v_count_1);
+*/
 
+/*
     // bring pq_strings to normal order
     std::vector<std::shared_ptr<pq_string>> ordered_center_strings;
     if (vacuum == "TRUE") {
@@ -917,14 +1039,49 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
             newguy->set_integrals("core", {idx1, idx2}, op_portions);
     
         }else if (op.substr(0, 1) == "f" || op.substr(0, 1) == "F") { // fock operator
+  
+            // normal ordered or not?
+            if ( op.size() == 1 ) { 
+                std::string idx1 = "p" + std::to_string(gen_label_count++);
+                std::string idx2 = "p" + std::to_string(gen_label_count++);
     
-            std::string idx1 = "p" + std::to_string(gen_label_count++);
-            std::string idx2 = "p" + std::to_string(gen_label_count++);
+                tmp_string.push_back(idx1+"*"); 
+                tmp_string.push_back(idx2);
     
-            tmp_string.push_back(idx1+"*"); 
-            tmp_string.push_back(idx2);
-    
-            newguy->set_integrals("fock", {idx1, idx2}, op_portions);
+                newguy->set_integrals("fock", {idx1, idx2}, op_portions);
+
+           }else {
+               // find number in string representing which block of F this is
+               std::string num_str = op.substr(1);
+               int label = std::stoi(num_str);
+
+               // Map the bits of 'label' (0 to 3) to 'o' (occupied) or 'v' (virtual)
+               // label & 2 checks the first index, label & 1 checks the second
+               std::string idx1 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+               std::string idx2 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+               
+               // Normal ordering: pushing true creators (C) left of true annihilators (A)
+               if (label == 0) {
+                   // 00 (v v) -> C A -> Already normal ordered
+                   tmp_string.push_back(idx1+"*"); 
+                   tmp_string.push_back(idx2);
+               }else if (label == 1) {
+                   // 01 (v o) -> C C -> Already normal ordered (preserve relative order)
+                   tmp_string.push_back(idx1+"*"); 
+                   tmp_string.push_back(idx2);
+               }else if (label == 2) {
+                   // 10 (o v) -> A A -> Already normal ordered (preserve relative order)
+                   tmp_string.push_back(idx1+"*"); 
+                   tmp_string.push_back(idx2);
+               }else if (label == 3) {
+                   // 11 (o o) -> A C -> Swap needed to put C before A
+                   factor *= -1;
+                   tmp_string.push_back(idx2); 
+                   tmp_string.push_back(idx1+"*");
+               }
+
+               newguy->set_integrals("fock", {idx1, idx2}, op_portions);
+           }
     
         }else if (op.substr(0, 2) == "d+" || op.substr(0, 2) == "D+") { // one-electron operator (dipole + boson creator)
     
@@ -1008,6 +1165,86 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 tmp_string.push_back(idx3);
                 tmp_string.push_back(idx4);
     
+                newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
+
+            }else if (op.substr(1, 1) == "n" ){ // normal ordered fluctuation potential
+
+                factor *= 0.25;
+
+                // find number in string representing which block of V (JN) this is
+                std::string num_str;
+                size_t pos = op.find('{', 2); // start in index 2
+                if (pos != std::string::npos) {
+                    num_str = op.substr(2, pos - 2);
+                } else {
+                    num_str = op.substr(2);
+                }
+                int label = std::stoi(num_str);
+
+                // Check the bits of 'label' to assign 'o' (occupied) or 'v' (virtual) 
+                // and increment the correct counter on the fly.
+                std::string idx1 = (label & 8) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                std::string idx2 = (label & 4) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                std::string idx3 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                std::string idx4 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+
+                // Normal ordering: pushing true creators (C) to the left of true annihilators (A)
+                if (label == 0) {
+                    // 0000 (v v v v) -> C C A A
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                }else if (label == 1) {
+                    // 0001 (v v v o) -> C C A C
+                    factor *= -1;
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx3);
+                }else if (label == 2) {
+                    // 0010 (v v o v) -> C C C A
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                }else if (label == 3) {
+                    // 0011 (v v o o) -> C C C C
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                }else if (label == 4) {
+                    // 0100 (v o v v) -> C A A A
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                }else if (label == 5) {
+                    // 0101 (v o v o) -> C A A C
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
+                }else if (label == 6) {
+                    // 0110 (v o o v) -> C A C A
+                    factor *= -1;
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
+                }else if (label == 7) {
+                    // 0111 (v o o o) -> C A C C
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*");
+                }else if (label == 8) {
+                    // 1000 (o v v v) -> A C A A
+                    factor *= -1;
+                    tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                }else if (label == 9) {
+                    // 1001 (o v v o) -> A C A C
+                    factor *= -1;
+                    tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3);
+                }else if (label == 10) {
+                    // 1010 (o v o v) -> A C C A
+                    tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4);
+                }else if (label == 11) {
+                    // 1011 (o v o o) -> A C C C
+                    factor *= -1;
+                    tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*");
+                }else if (label == 12) {
+                    // 1100 (o o v v) -> A A A A
+                    tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                }else if (label == 13) {
+                    // 1101 (o o v o) -> A A A C
+                    factor *= -1;
+                    tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
+                }else if (label == 14) {
+                    // 1110 (o o o v) -> A A C A
+                    tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
+                }else if (label == 15) {
+                    // 1111 (o o o o) -> A A C C
+                    tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*");
+                }
+                
                 newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
             }
     

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -568,46 +568,6 @@ void pq_helper::add_hextuple_commutator(double factor,
     process_operator_products(ops);
 }
 
-void pq_helper::process_operator_products(std::vector<pq_operator_terms> ops) {
-
-    // 'v' = 'j1' + 'j2'
-    bool done_processing = false;
-    std::vector<pq_operator_terms> new_ops;
-    do {
-        std::tie(done_processing, new_ops) = process_fluctuation_potential(ops);
-        ops = new_ops;
-    }while(!done_processing);
-
-    // 't1' = 't1e' or 't1' = 't1e' - 't1d', etc.
-    done_processing = false;
-    do {
-        std::tie(done_processing, new_ops) = process_cluster_amplitudes(ops);
-        ops = new_ops;
-    }while(!done_processing);
-
-    if (is_hamiltonian_normal_ordered) {
-        // TODO: normal order 'j2' and drop 'j1' 
-        // TODO: normal order 'f' 
-        printf("\n");
-        printf("    error: the normal ordered hamiltonian operators are broken\n");
-        printf("\n");
-        exit(1);
-    }
-
-    // TODO: normal order the entire argument, if desired
-
-    for (auto op : ops){
-        add_operator_product(op.factor, op.operators);
-    }
-}
-
-// wrapper for python calling add_operator_product directly
-void pq_helper::py_add_operator_product(double factor, std::vector<std::string>  in){
-
-    std::vector<pq_operator_terms> ops = {pq_operator_terms( factor, in)};
-    process_operator_products(ops);
-
-}
 
 // check if there are fluctuation potential operators that needs to be split into multiple terms
 std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_fluctuation_potential(std::vector<pq_operator_terms> ops_in){
@@ -778,15 +738,75 @@ std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_cluster_amplit
     return std::make_pair(done_processing, ops_out);
 }
 
+void pq_helper::process_operator_products(std::vector<pq_operator_terms> ops) {
+
+    bool done_processing = false;
+    std::vector<pq_operator_terms> new_ops;
+
+    // check for fluctuation potential because it should be split as
+    // 'v' = 'j1' + 'j2'
+    do {
+        std::tie(done_processing, new_ops) = process_fluctuation_potential(ops);
+        ops = new_ops;
+    }while(!done_processing);
+
+    // check for cluster amplitudes because they should be renamed/split as
+    // 't1' = 't1e' or 't1' = 't1e' - 't1d', etc.
+    done_processing = false;
+    do {
+        std::tie(done_processing, new_ops) = process_cluster_amplitudes(ops);
+        ops = new_ops;
+    }while(!done_processing);
+
+    if (is_hamiltonian_normal_ordered) {
+        // TODO: normal order 'j2' and drop 'j1' 
+        // TODO: normal order 'f' 
+        printf("\n");
+        printf("    error: the normal ordered hamiltonian operators are broken\n");
+        printf("\n");
+        exit(1);
+    }
+
+    // normal order the central operator, if desired
+    /*if (is_central_operator_normal_ordered) {
+
+        std::vector<std::vector<std::string> save_left_operators;
+        for (const std::vector<std::string> & ops : left_operators) {
+            save_left_operators.push_back(ops);
+        }
+
+        std::vector<std::vector<std::string> save_right_operators;
+        for (const std::vector<std::string> & ops : right_operators) {
+            save_right_operators.push_back(ops);
+        }
+
+        left_operators.clear();
+        right_operators.clear();
+
+        for (const std::vector<std::string> & ops : save_left_operators) {
+            left_operators.push_back(ops);
+        }
+        for (const std::vector<std::string> & ops : save_right_operators) {
+            left_operators.push_back(ops);
+        }
+    }*/
+
+    for (auto op : ops){
+        add_operator_product(op.factor, op.operators);
+    }
+}
+
+// wrapper for python calling add_operator_product directly
+void pq_helper::py_add_operator_product(double factor, std::vector<std::string>  in){
+
+    std::vector<pq_operator_terms> ops = {pq_operator_terms(factor, in)};
+    process_operator_products(ops);
+}
+
 // add a string of operators
 void pq_helper::add_operator_product(double factor, std::vector<std::string>  in){
 
     // apply any extra operators on left or right:
-    std::vector<std::string> save;
-    for (const std::string & op : in) {
-        save.push_back(op);
-    }
-
     if ( (int)left_operators.size() == 0 ) {
         std::vector<std::string> junk;
         junk.emplace_back("1");
@@ -798,709 +818,15 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
         right_operators.push_back(junk);
     }
 
-    // build strings
-    double original_factor = factor;
-
     for (std::vector<std::string> & left_operator : left_operators) {
         for (std::vector<std::string> & right_operator : right_operators) {
 
-            std::shared_ptr<pq_string> newguy (new pq_string(vacuum));
-
-            factor = original_factor;
-
-            std::vector<std::string> tmp_string;
-
-            bool has_w0       = false;
-
+            // build pq_strings
             int occ_label_count = 0;
             int vir_label_count = 0;
-            int gen_label_count = 0;
+            std::shared_ptr<pq_string> newguy = build_new_string(factor, left_operator, in, right_operator, occ_label_count, vir_label_count);
 
-            // apply any extra operators on left or right:
-            std::vector<std::string> tmp = left_operator;
-            for (const std::string & op : save) {
-                tmp.push_back(op);
-            }
-            for (const std::string & op : right_operator) {
-                tmp.push_back(op);
-            }
-
-            for (std::string & op_including_portions : tmp) {
-
-                // bernoulli expansion requires operator portion specification. split into base name and portion
-                std::string op = get_operator_base_name(op_including_portions);
-                std::vector<std::string> op_portions = get_operator_portions_as_vector(op_including_portions);
-                
-                // blank string
-                if ( op.empty() ) continue;
-
-                // Stephen: removed so that we can distinguish lower- and uppercase indices
-                // lowercase indices
-                // std::transform(op.begin(), op.end(), op.begin(), [](unsigned char c){ return std::tolower(c); });
-
-                // remove spaces
-                removeSpaces(op);
-
-                // remove parentheses
-                removeParentheses(op);
-
-                if (op.substr(0, 1) == "h" || op.substr(0, 1) == "H") { // one-electron operator
-
-                    std::string idx1 = "p" + std::to_string(gen_label_count++);
-                    std::string idx2 = "p" + std::to_string(gen_label_count++);
-
-                    // index 1
-                    tmp_string.push_back(idx1+"*");
-
-                    // index 2
-                    tmp_string.push_back(idx2);
-
-                    // integrals
-                    newguy->set_integrals("core", {idx1, idx2}, op_portions);
-
-                }else if (op.substr(0, 1) == "f" || op.substr(0, 1) == "F") { // fock operator
-
-                    if ( is_hamiltonian_normal_ordered ) {
-
-                        // find number in string representing which block of F this is
-                        std::string num_str;
-                        size_t pos = op.find('{', 1); // start in position 1
-                        if (pos != std::string::npos) {
-                            num_str = op.substr(1, pos - 1);
-                        } else {
-                            num_str = op.substr(1);
-                        }
-                        int label = std::stoi(num_str);
-
-                        // Map the bits of 'label' (0 to 3) to 'o' (occupied) or 'v' (virtual)
-                        // label & 2 checks the first index, label & 1 checks the second
-                        std::string idx1 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                        std::string idx2 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                        
-                        // Normal ordering: pushing true creators (C) left of true annihilators (A)
-                        if (label == 0) {
-                            // 00 (v v) -> C A -> Already normal ordered
-                            tmp_string.push_back(idx1+"*"); 
-                            tmp_string.push_back(idx2);
-                        }else if (label == 1) {
-                            // 01 (v o) -> C C -> Already normal ordered (preserve relative order)
-                            tmp_string.push_back(idx1+"*"); 
-                            tmp_string.push_back(idx2);
-                        }else if (label == 2) {
-                            // 10 (o v) -> A A -> Already normal ordered (preserve relative order)
-                            tmp_string.push_back(idx1+"*"); 
-                            tmp_string.push_back(idx2);
-                        }else if (label == 3) {
-                            // 11 (o o) -> A C -> Swap needed to put C before A
-                            factor *= -1;
-                            tmp_string.push_back(idx2); 
-                            tmp_string.push_back(idx1+"*");
-                        }
-
-                        newguy->set_integrals("fock", {idx1, idx2}, op_portions);
-                    }else {
-                        std::string idx1 = "p" + std::to_string(gen_label_count++);
-                        std::string idx2 = "p" + std::to_string(gen_label_count++);
-
-                        tmp_string.push_back(idx1+"*"); 
-                        tmp_string.push_back(idx2);
-
-                        newguy->set_integrals("fock", {idx1, idx2}, op_portions);
-                    }
-
-
-
-                }else if (op.substr(0, 2) == "d+" || op.substr(0, 2) == "D+") { // one-electron operator (dipole + boson creator)
-
-                    std::string idx1 = "p" + std::to_string(gen_label_count++);
-                    std::string idx2 = "p" + std::to_string(gen_label_count++);
-
-                    // index 1
-                    tmp_string.push_back(idx1+"*");
-
-                    // index 2
-                    tmp_string.push_back(idx2);
-
-                    // integrals
-                    newguy->set_integrals("d+", {idx1, idx2}, op_portions);
-
-                    // boson operator
-                    newguy->is_boson_dagger.push_back(true);
-
-                }else if (op.substr(0, 2) == "d-" || op.substr(0, 2) == "D-") { // one-electron operator (dipole + boson annihilator)
-
-                    std::string idx1 = "p" + std::to_string(gen_label_count++);
-                    std::string idx2 = "p" + std::to_string(gen_label_count++);
-
-                    // index 1
-                    tmp_string.push_back(idx1+"*");
-
-                    // index 2
-                    tmp_string.push_back(idx2);
-
-                    // integrals
-                    newguy->set_integrals("d-", {idx1, idx2}, op_portions);
-
-                    // boson operator
-                    newguy->is_boson_dagger.push_back(false);
-
-                }else if (op.substr(0, 1) == "g" || op.substr(0, 1) == "G") { // general two-electron operator
-
-                    //factor *= 0.25;
-
-                    std::string idx1 = "p" + std::to_string(gen_label_count++);
-                    std::string idx2 = "p" + std::to_string(gen_label_count++);
-                    std::string idx3 = "p" + std::to_string(gen_label_count++);
-                    std::string idx4 = "p" + std::to_string(gen_label_count++);
-
-                    tmp_string.push_back(idx1+"*");
-                    tmp_string.push_back(idx2+"*");
-                    tmp_string.push_back(idx3);
-                    tmp_string.push_back(idx4);
-
-                    newguy->set_integrals("two_body", {idx1, idx2, idx4, idx3}, op_portions);
-
-                }else if (op.substr(0, 1) == "j" || op.substr(0, 1) == "J") { // fluctuation potential
-
-                    if (op.substr(1, 1) == "1" ){
-
-                        // no contribution from -<pi||qi> p*q if hamiltonian is normal ordered
-                        if ( is_hamiltonian_normal_ordered ) {
-                            return;
-                        }
-
-                        factor *= -1.0;
-
-                        std::string idx1 = "p" + std::to_string(gen_label_count++);
-                        std::string idx2 = "p" + std::to_string(gen_label_count++);
-
-                        // index 1
-                        tmp_string.push_back(idx1+"*");
-
-                        // index 2
-                        tmp_string.push_back(idx2);
-
-                        // integrals
-                        newguy->set_integrals("occ_repulsion", {idx1, idx2}, op_portions);
-
-                    }else if (op.substr(1, 1) == "2" ){
-
-                        factor *= 0.25;
-
-                        if ( is_hamiltonian_normal_ordered ) {
-
-                            // find number in string representing which block of V (J2) this is
-                            std::string num_str;
-                            size_t pos = op.find('{', 2); // start in index 2
-                            if (pos != std::string::npos) {
-                                num_str = op.substr(2, pos - 2);
-                            } else {
-                                num_str = op.substr(2);
-                            }
-                            int label = std::stoi(num_str);
-
-                            // Check the bits of 'label' to assign 'o' (occupied) or 'v' (virtual) 
-                            // and increment the correct counter on the fly.
-                            std::string idx1 = (label & 8) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                            std::string idx2 = (label & 4) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                            std::string idx3 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                            std::string idx4 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-
-                            // Normal ordering: pushing true creators (C) to the left of true annihilators (A)
-                            if (label == 0) {
-                                // 0000 (v v v v) -> C C A A
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                            }else if (label == 1) {
-                                // 0001 (v v v o) -> C C A C
-                                factor *= -1;
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx3);
-                            }else if (label == 2) {
-                                // 0010 (v v o v) -> C C C A
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                            }else if (label == 3) {
-                                // 0011 (v v o o) -> C C C C
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                            }else if (label == 4) {
-                                // 0100 (v o v v) -> C A A A
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                            }else if (label == 5) {
-                                // 0101 (v o v o) -> C A A C
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
-                            }else if (label == 6) {
-                                // 0110 (v o o v) -> C A C A
-                                factor *= -1;
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
-                            }else if (label == 7) {
-                                // 0111 (v o o o) -> C A C C
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*");
-                            }else if (label == 8) {
-                                // 1000 (o v v v) -> A C A A
-                                factor *= -1;
-                                tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                            }else if (label == 9) {
-                                // 1001 (o v v o) -> A C A C
-                                factor *= -1;
-                                tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3);
-                            }else if (label == 10) {
-                                // 1010 (o v o v) -> A C C A
-                                tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4);
-                            }else if (label == 11) {
-                                // 1011 (o v o o) -> A C C C
-                                factor *= -1;
-                                tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*");
-                            }else if (label == 12) {
-                                // 1100 (o o v v) -> A A A A
-                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                            }else if (label == 13) {
-                                // 1101 (o o v o) -> A A A C
-                                factor *= -1;
-                                tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
-                            }else if (label == 14) {
-                                // 1110 (o o o v) -> A A C A
-                                tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
-                            }else if (label == 15) {
-                                // 1111 (o o o o) -> A A C C
-                                tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*");
-                            }
-                            
-                            newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
-                        }else {
-                        
-                            std::string idx1 = "p" + std::to_string(gen_label_count++);
-                            std::string idx2 = "p" + std::to_string(gen_label_count++);
-                            std::string idx3 = "p" + std::to_string(gen_label_count++);
-                            std::string idx4 = "p" + std::to_string(gen_label_count++);
-
-                            tmp_string.push_back(idx1+"*");
-                            tmp_string.push_back(idx2+"*");
-                            tmp_string.push_back(idx3);
-                            tmp_string.push_back(idx4);
-
-                            newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
-                        }
-                    }
-
-                }else if (op.substr(0, 1) == "t"){
-
-                    int n = std::stoi(op.substr(2));
-                    std::vector<std::string> labels;
-
-                    if ( n == 0 ){
-
-                        // nothing to do
-
-                    }else {
-
-                        std::vector<std::string> op_left;
-                        std::vector<std::string> op_right;
-                        std::vector<std::string> label_left;
-                        std::vector<std::string> label_right;
- 
-                        // excitation:
-                        if ( op.substr(0,2) == "te" ) {
-
-                            for (int id = 0; id < n; id++) {
-
-                                std::string idx1 = "v" + std::to_string(vir_label_count++);
-                                std::string idx2 = "o" + std::to_string(occ_label_count++);
-
-                                op_left.push_back(idx1+"*");
-                                op_right.push_back(idx2);
-
-                                label_left.push_back(idx1);
-                                label_right.push_back(idx2);
-                            }
-                        }else if ( op.substr(0,2) == "td" ) {
-
-                            // de-excitation:
-                            for (int id = 0; id < n; id++) {
-
-                                std::string idx1 = "v" + std::to_string(vir_label_count++);
-                                std::string idx2 = "o" + std::to_string(occ_label_count++);
-
-                                op_left.push_back(idx2+"*");
-                                op_right.push_back(idx1);
-
-                                // do not transpose de-excitation amplitude labels
-                                //label_left.push_back(idx1);
-                                //label_right.push_back(idx2);
-                                // transpose de-excitation amplitude labels
-                                label_left.push_back(idx2);
-                                label_right.push_back(idx1);
-                            }
-                        }else {
-                            printf("\n");
-                            printf("    invalid operator type: %s\n", op.c_str());
-                            printf("\n");
-                            exit(1);
-                        }
-
-                        // a*b*...
-                        for (int id = 0; id < n; id++) {
-                            tmp_string.push_back(op_left[id]);
-                        }
-                        // op*j*...
-                        for (int id = 0; id < n; id++) {
-                            tmp_string.push_back(op_right[id]);
-                        }
-
-                        // tn(ab...
-                        for (int id = 0; id < n; id++) {
-                            labels.push_back(label_left[id]);
-                        }
-                        // tn(ab......ji)
-                        for (int id = n-1; id >= 0; id--) {
-                            labels.push_back(label_right[id]);
-                        }
-
-                        // factor = 1/(n!)^2
-                        double my_factor = 1.0;
-                        for (int id = 0; id < n; id++) {
-                            my_factor *= (id+1);
-                        }
-                        factor *= 1.0 / my_factor / my_factor;
-                    }
-
-                    int n_ph = 0;
-                    if (op.size() > 3 ) {
-                        if ( op.substr(3,1) == ",") {
-                            n_ph = std::stoi(op.substr(4));
-                            if ( op.substr(0,2) == "te" ) {
-                                // excitation
-                                for (int ph = 0; ph < n_ph; ph++) {
-                                    newguy->is_boson_dagger.push_back(true);
-                                }
-                            }else if ( op.substr(0,2) == "td" ) {
-                                // de-excitation
-                                for (int ph = 0; ph < n_ph; ph++) {
-                                    newguy->is_boson_dagger.push_back(false);
-                                }
-                            }
-                        }
-                    }
-                    newguy->set_amplitudes('t', n, n, n_ph, labels, op_portions);
-
-                }else if (op.substr(0, 1) == "w" || op.substr(0, 1) == "W"){ // w0 B*B
-
-                    if (op.substr(1, 1) == "0" ){
-
-                        has_w0 = true;
-
-                        newguy->is_boson_dagger.push_back(true);
-                        newguy->is_boson_dagger.push_back(false);
-
-                    }else {
-                        printf("\n");
-                        printf("    error: only w0 is supported\n");
-                        printf("\n");
-                        exit(1);
-                    }
-
-                }else if (op.substr(0, 2) == "b+" || op.substr(0, 2) == "B+"){ // B*
-
-                        newguy->is_boson_dagger.push_back(true);
-
-                }else if (op.substr(0, 2) == "b-" || op.substr(0, 2) == "B-"){ // B
-
-                        newguy->is_boson_dagger.push_back(false);
-
-                }else if (op.substr(0, 1) == "r" || op.substr(0, 1) == "R"){
-
-
-                    int n = std::stoi(op.substr(1));
-                    int n_annihilate = n;
-                    int n_create     = n;
-                    std::vector<std::string> labels;
-
-                    if ( n == 0 ){
-
-                        // nothing to do
-
-                    }else {
-
-                        if ( right_operators_type == "IP" ) n_create--;
-                        if ( right_operators_type == "DIP" ) n_create -= 2;
-                        if ( right_operators_type == "EA" ) n_annihilate--;
-                        if ( right_operators_type == "DEA" ) n_annihilate -= 2;
-
-                        std::vector<std::string> op_left;
-                        std::vector<std::string> op_right;
-                        std::vector<std::string> label_left;
-                        std::vector<std::string> label_right;
-                        for (int id = 0; id < n_create; id++) {
-                            std::string idx1 = "v" + std::to_string(vir_label_count++);
-                            op_left.push_back(idx1+"*");
-                            label_left.push_back(idx1);
-                        }
-                        for (int id = 0; id < n_annihilate; id++) {
-                            std::string idx2 = "o" + std::to_string(occ_label_count++);
-                            op_right.push_back(idx2);
-                            label_right.push_back(idx2);
-                        }
-                        // a*b*...
-                        for (int id = 0; id < n_create; id++) {
-                            tmp_string.push_back(op_left[id]);
-                        }
-                        // ij...
-                        for (int id = 0; id < n_annihilate; id++) {
-                            tmp_string.push_back(op_right[id]);
-                        }
-
-                        // tn(ab...
-                        for (int id = 0; id < n_create; id++) {
-                            labels.push_back(label_left[id]);
-                        }
-                        // tn(ab......ji)
-                        for (int id = n_annihilate-1; id >= 0; id--) {
-                            labels.push_back(label_right[id]);
-                        }
-
-                        // factor = 1/(n!)^2
-                        double my_factor_create = 1.0;
-                        double my_factor_annihilate = 1.0;
-                        for (int id = 0; id < n_create; id++) {
-                            my_factor_create *= (id+1);
-                        }
-                        for (int id = 0; id < n_annihilate; id++) {
-                            my_factor_annihilate *= (id+1);
-                        }
-                        factor *= 1.0 / my_factor_create / my_factor_annihilate;
-                    }
-
-                    int n_ph = 0;
-                    if (op.size() > 2 ) {
-                        if ( op.substr(2,1) == ",") {
-                            n_ph = std::stoi(op.substr(3));
-                            for (int ph = 0; ph < n_ph; ph++) {
-                                newguy->is_boson_dagger.push_back(true);
-                            }
-                        }
-                    }
-                    newguy->set_amplitudes('r', n_create, n_annihilate, n_ph, labels, op_portions);
-
-                }else if (op.substr(0, 1) == "l" || op.substr(0, 1) == "L"){
-
-                    int n = std::stoi(op.substr(1));
-                    int n_annihilate = n;
-                    int n_create     = n;
-                    std::vector<std::string> labels;
-
-                    if ( n == 0 ){
-
-                        // nothing to do
-
-                    }else {
-                        
-                        if ( left_operators_type == "IP" ) n_annihilate--;
-                        if ( left_operators_type == "DIP" ) n_annihilate -= 2;
-                        if ( left_operators_type == "EA" ) n_create--;
-                        if ( left_operators_type == "DEA" ) n_create -= 2;
-
-                        std::vector<std::string> op_left;
-                        std::vector<std::string> op_right;
-                        std::vector<std::string> label_left;
-                        std::vector<std::string> label_right;
-                        for (int id = 0; id < n_create; id++) {
-                            std::string idx1 = "o" + std::to_string(occ_label_count++);
-                            op_left.push_back(idx1+"*");
-                            label_left.push_back(idx1);
-                        }
-                        for (int id = 0; id < n_annihilate; id++) {
-                            std::string idx2 = "v" + std::to_string(vir_label_count++);
-                            op_right.push_back(idx2);
-                            label_right.push_back(idx2);
-                        }
-                        // op*j*...
-                        for (int id = 0; id < n_create; id++) {
-                            tmp_string.push_back(op_left[id]);
-                        }
-                        // ab...
-                        for (int id = 0; id < n_annihilate; id++) {
-                            tmp_string.push_back(op_right[id]);
-                        }
-
-                        // tn(ij... 
-                        for (int id = 0; id < n_create; id++) {
-                            labels.push_back(label_left[id]);
-                        }
-                        // tn(ij......ba)
-                        for (int id = n_annihilate-1; id >= 0; id--) {
-                            labels.push_back(label_right[id]);
-                        }
-                        
-                        // factor = 1/(n!)^2
-                        double my_factor_create = 1.0;
-                        double my_factor_annihilate = 1.0;
-                        for (int id = 0; id < n_create; id++) {
-                            my_factor_create *= (id+1);
-                        }
-                        for (int id = 0; id < n_annihilate; id++) {
-                            my_factor_annihilate *= (id+1);
-                        }
-                        factor *= 1.0 / my_factor_create / my_factor_annihilate;
-                    
-                    }
-
-                    int n_ph = 0;
-                    if (op.size() > 2 ) {
-                        if ( op.substr(2,1) == ",") {
-                            n_ph = std::stoi(op.substr(3));
-                            for (int ph = 0; ph < n_ph; ph++) {
-                                newguy->is_boson_dagger.push_back(false);
-                            }
-                        }
-                    }
-                    newguy->set_amplitudes('l', n_create, n_annihilate, n_ph, labels, op_portions);
-
-                }else if (op.substr(0, 1) == "e" || op.substr(0, 1) == "E"){
-
-
-                    if (op.substr(1, 1) == "1" ){
-
-                        // find comma
-                        size_t pos = op.find(',');
-                        if ( pos == std::string::npos ) {
-                            printf("\n");
-                            printf("    error in e1 operator definition\n");
-                            printf("\n");
-                            exit(1);
-                        }
-                        size_t len = pos - 2; 
-
-                        // index 1
-                        tmp_string.push_back(op.substr(2, len) + "*");
-
-                        // index 2
-                        tmp_string.push_back(op.substr(pos + 1));
-
-                    }else if (op.substr(1, 1) == "2" ){
-
-                        // count indices
-                        size_t pos = 0;
-                        int ncomma = 0;
-                        std::vector<size_t> commas;
-                        pos = op.find(',', pos + 1);
-                        commas.push_back(pos);
-                        while( pos != std::string::npos){
-                            pos = op.find(',', pos + 1);
-                            commas.push_back(pos);
-                            ncomma++;
-                        }
-
-                        if ( ncomma != 3 ) {
-                            printf("\n");
-                            printf("    error in e2 definition\n");
-                            printf("\n");
-                            exit(1);
-                        }
-
-                        tmp_string.push_back(op.substr(2, commas[0] - 2) + "*");
-                        tmp_string.push_back(op.substr(commas[0] + 1, commas[1] - commas[0] - 1) + "*");
-                        tmp_string.push_back(op.substr(commas[1] + 1, commas[2] - commas[1] - 1));
-                        tmp_string.push_back(op.substr(commas[2] + 1));
-
-                    }else if (op.substr(1, 1) == "3" ){
-
-                        // count indices
-                        size_t pos = 0;
-                        int ncomma = 0;
-                        std::vector<size_t> commas;
-                        pos = op.find(',', pos + 1);
-                        commas.push_back(pos);
-                        while( pos != std::string::npos){
-                            pos = op.find(',', pos + 1);
-                            commas.push_back(pos);
-                            ncomma++;
-                        }
-
-                        if ( ncomma != 5 ) {
-                            printf("\n");
-                            printf("    error in e3 definition\n");
-                            printf("\n");
-                            exit(1);
-                        }
-
-                        tmp_string.push_back(op.substr(2, commas[0] - 2) + "*");
-                        tmp_string.push_back(op.substr(commas[0] + 1, commas[1] - commas[0] - 1) + "*");
-                        tmp_string.push_back(op.substr(commas[1] + 1, commas[2] - commas[1] - 1) + "*");
-                        tmp_string.push_back(op.substr(commas[2] + 1, commas[3] - commas[2] - 1));
-                        tmp_string.push_back(op.substr(commas[3] + 1, commas[4] - commas[3] - 1));
-                        tmp_string.push_back(op.substr(commas[4] + 1));
-
-                    }else if (op.substr(1, 1) == "4" ){
-
-                        // count indices
-                        size_t pos = 0;
-                        int ncomma = 0;
-                        std::vector<size_t> commas;
-                        pos = op.find(',', pos + 1);
-                        commas.push_back(pos);
-                        while( pos != std::string::npos){
-                            pos = op.find(',', pos + 1);
-                            commas.push_back(pos);
-                            ncomma++;
-                        }
-
-                        if ( ncomma != 7 ) {
-                            printf("\n");
-                            printf("    error in e4 definition\n");
-                            printf("\n");
-                            exit(1);
-                        }
-
-                        tmp_string.push_back(op.substr(2, commas[0] - 2) + "*");
-                        tmp_string.push_back(op.substr(commas[0] + 1, commas[1] - commas[0] - 1) + "*");
-                        tmp_string.push_back(op.substr(commas[1] + 1, commas[2] - commas[1] - 1) + "*");
-                        tmp_string.push_back(op.substr(commas[2] + 1, commas[3] - commas[2] - 1) + "*");
-                        tmp_string.push_back(op.substr(commas[3] + 1, commas[4] - commas[3] - 1));
-                        tmp_string.push_back(op.substr(commas[4] + 1, commas[5] - commas[4] - 1));
-                        tmp_string.push_back(op.substr(commas[5] + 1, commas[6] - commas[5] - 1));
-                        tmp_string.push_back(op.substr(commas[6] + 1));
-
-                    }else {
-                        printf("\n");
-                        printf("    error: only e1, e2, e3, and e4 operators are supported\n");
-                        printf("\n");
-                        exit(1);
-                    }
-
-                }else if (op.substr(0, 1) == "1" ) { // unit operator ... do nothing
-
-                }else if (op.substr(0, 1) == "a" || op.substr(0, 1) == "A"){ // single creator / annihilator
-
-
-                    if (op.substr(1, 1) == "*" ){ // creator
-
-                        tmp_string.push_back(op.substr(1) + "*");
-
-                    }else { // annihilator
-
-                        tmp_string.push_back(op.substr(1));
-
-                    }
-
-                }else {
-                        printf("\n");
-                        printf("    error: undefined string: %s\n", op.c_str());
-                        printf("\n");
-                        exit(1);
-                }
-            }
-
-            newguy->factor = factor;
-
-            for (const std::string & op : tmp_string) {
-                newguy->string.push_back(op);
-            }
-
-            newguy->has_w0 = has_w0;
-
-            // make sure factor > 0
-            if ( newguy->factor < 0.0 ) {
-                newguy->factor = fabs(newguy->factor);
-                newguy->sign *= -1;
-            }
-
+            // bring pq_strings to normal order
             if (vacuum == "TRUE") {
                 add_new_string_true_vacuum(newguy, ordered, print_level, find_paired_permutations);
             } else {
@@ -1508,6 +834,713 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
             }
         }
     }
+}
+
+// build a pq_string from the string representations of operators
+std::shared_ptr<pq_string> pq_helper::build_new_string(double factor, 
+    std::vector<std::string> left_op, 
+    std::vector<std::string> central_op, 
+    std::vector<std::string> right_op,
+    int & occ_label_count,
+    int & vir_label_count){
+
+    std::shared_ptr<pq_string> newguy (new pq_string(vacuum));
+    
+    std::vector<std::string> tmp_string;
+    
+    bool has_w0       = false;
+    
+    occ_label_count = 0;
+    vir_label_count = 0;
+    int gen_label_count = 0;
+    
+    // apply any extra operators on left or right:
+    std::vector<std::string> tmp = left_op;
+    for (const std::string & op : central_op) {
+        tmp.push_back(op);
+    }
+    for (const std::string & op : right_op) {
+        tmp.push_back(op);
+    }
+    
+    for (std::string & op_including_portions : tmp) {
+    
+        // bernoulli expansion requires operator portion specification. split into base name and portion
+        std::string op = get_operator_base_name(op_including_portions);
+        std::vector<std::string> op_portions = get_operator_portions_as_vector(op_including_portions);
+        
+        // blank string
+        if ( op.empty() ) continue;
+    
+        // Stephen: removed so that we can distinguish lower- and uppercase indices
+        // lowercase indices
+        // std::transform(op.begin(), op.end(), op.begin(), [](unsigned char c){ return std::tolower(c); });
+    
+        // remove spaces
+        removeSpaces(op);
+    
+        // remove parentheses
+        removeParentheses(op);
+    
+        if (op.substr(0, 1) == "h" || op.substr(0, 1) == "H") { // one-electron operator
+    
+            std::string idx1 = "p" + std::to_string(gen_label_count++);
+            std::string idx2 = "p" + std::to_string(gen_label_count++);
+    
+            // index 1
+            tmp_string.push_back(idx1+"*");
+    
+            // index 2
+            tmp_string.push_back(idx2);
+    
+            // integrals
+            newguy->set_integrals("core", {idx1, idx2}, op_portions);
+    
+        }else if (op.substr(0, 1) == "f" || op.substr(0, 1) == "F") { // fock operator
+    
+            if ( is_hamiltonian_normal_ordered ) {
+    
+                // find number in string representing which block of F this is
+                std::string num_str;
+                size_t pos = op.find('{', 1); // start in position 1
+                if (pos != std::string::npos) {
+                    num_str = op.substr(1, pos - 1);
+                } else {
+                    num_str = op.substr(1);
+                }
+                int label = std::stoi(num_str);
+    
+                // Map the bits of 'label' (0 to 3) to 'o' (occupied) or 'v' (virtual)
+                // label & 2 checks the first index, label & 1 checks the second
+                std::string idx1 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                std::string idx2 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                
+                // Normal ordering: pushing true creators (C) left of true annihilators (A)
+                if (label == 0) {
+                    // 00 (v v) -> C A -> Already normal ordered
+                    tmp_string.push_back(idx1+"*"); 
+                    tmp_string.push_back(idx2);
+                }else if (label == 1) {
+                    // 01 (v o) -> C C -> Already normal ordered (preserve relative order)
+                    tmp_string.push_back(idx1+"*"); 
+                    tmp_string.push_back(idx2);
+                }else if (label == 2) {
+                    // 10 (o v) -> A A -> Already normal ordered (preserve relative order)
+                    tmp_string.push_back(idx1+"*"); 
+                    tmp_string.push_back(idx2);
+                }else if (label == 3) {
+                    // 11 (o o) -> A C -> Swap needed to put C before A
+                    factor *= -1;
+                    tmp_string.push_back(idx2); 
+                    tmp_string.push_back(idx1+"*");
+                }
+    
+                newguy->set_integrals("fock", {idx1, idx2}, op_portions);
+            }else {
+                std::string idx1 = "p" + std::to_string(gen_label_count++);
+                std::string idx2 = "p" + std::to_string(gen_label_count++);
+    
+                tmp_string.push_back(idx1+"*"); 
+                tmp_string.push_back(idx2);
+    
+                newguy->set_integrals("fock", {idx1, idx2}, op_portions);
+            }
+    
+        }else if (op.substr(0, 2) == "d+" || op.substr(0, 2) == "D+") { // one-electron operator (dipole + boson creator)
+    
+            std::string idx1 = "p" + std::to_string(gen_label_count++);
+            std::string idx2 = "p" + std::to_string(gen_label_count++);
+    
+            // index 1
+            tmp_string.push_back(idx1+"*");
+    
+            // index 2
+            tmp_string.push_back(idx2);
+    
+            // integrals
+            newguy->set_integrals("d+", {idx1, idx2}, op_portions);
+    
+            // boson operator
+            newguy->is_boson_dagger.push_back(true);
+    
+        }else if (op.substr(0, 2) == "d-" || op.substr(0, 2) == "D-") { // one-electron operator (dipole + boson annihilator)
+    
+            std::string idx1 = "p" + std::to_string(gen_label_count++);
+            std::string idx2 = "p" + std::to_string(gen_label_count++);
+    
+            // index 1
+            tmp_string.push_back(idx1+"*");
+    
+            // index 2
+            tmp_string.push_back(idx2);
+    
+            // integrals
+            newguy->set_integrals("d-", {idx1, idx2}, op_portions);
+    
+            // boson operator
+            newguy->is_boson_dagger.push_back(false);
+    
+        }else if (op.substr(0, 1) == "g" || op.substr(0, 1) == "G") { // general two-electron operator
+    
+            //factor *= 0.25;
+    
+            std::string idx1 = "p" + std::to_string(gen_label_count++);
+            std::string idx2 = "p" + std::to_string(gen_label_count++);
+            std::string idx3 = "p" + std::to_string(gen_label_count++);
+            std::string idx4 = "p" + std::to_string(gen_label_count++);
+    
+            tmp_string.push_back(idx1+"*");
+            tmp_string.push_back(idx2+"*");
+            tmp_string.push_back(idx3);
+            tmp_string.push_back(idx4);
+    
+            newguy->set_integrals("two_body", {idx1, idx2, idx4, idx3}, op_portions);
+    
+        }else if (op.substr(0, 1) == "j" || op.substr(0, 1) == "J") { // fluctuation potential
+    
+            if (op.substr(1, 1) == "1" ){
+    
+                // no contribution from -<pi||qi> p*q if hamiltonian is normal ordered
+                if ( is_hamiltonian_normal_ordered ) {
+                    printf("\n");
+                    printf("    normal ordered hamiltonian is broken\n");
+                    printf("\n");
+                    exit(1);
+                    return newguy;
+                }
+    
+                factor *= -1.0;
+    
+                std::string idx1 = "p" + std::to_string(gen_label_count++);
+                std::string idx2 = "p" + std::to_string(gen_label_count++);
+    
+                // index 1
+                tmp_string.push_back(idx1+"*");
+    
+                // index 2
+                tmp_string.push_back(idx2);
+    
+                // integrals
+                newguy->set_integrals("occ_repulsion", {idx1, idx2}, op_portions);
+    
+            }else if (op.substr(1, 1) == "2" ){
+    
+                factor *= 0.25;
+    
+                if ( is_hamiltonian_normal_ordered ) {
+    
+                    // find number in string representing which block of V (J2) this is
+                    std::string num_str;
+                    size_t pos = op.find('{', 2); // start in index 2
+                    if (pos != std::string::npos) {
+                        num_str = op.substr(2, pos - 2);
+                    } else {
+                        num_str = op.substr(2);
+                    }
+                    int label = std::stoi(num_str);
+    
+                    // Check the bits of 'label' to assign 'o' (occupied) or 'v' (virtual) 
+                    // and increment the correct counter on the fly.
+                    std::string idx1 = (label & 8) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                    std::string idx2 = (label & 4) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                    std::string idx3 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                    std::string idx4 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+    
+                    // Normal ordering: pushing true creators (C) to the left of true annihilators (A)
+                    if (label == 0) {
+                        // 0000 (v v v v) -> C C A A
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                    }else if (label == 1) {
+                        // 0001 (v v v o) -> C C A C
+                        factor *= -1;
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx3);
+                    }else if (label == 2) {
+                        // 0010 (v v o v) -> C C C A
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                    }else if (label == 3) {
+                        // 0011 (v v o o) -> C C C C
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                    }else if (label == 4) {
+                        // 0100 (v o v v) -> C A A A
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                    }else if (label == 5) {
+                        // 0101 (v o v o) -> C A A C
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
+                    }else if (label == 6) {
+                        // 0110 (v o o v) -> C A C A
+                        factor *= -1;
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
+                    }else if (label == 7) {
+                        // 0111 (v o o o) -> C A C C
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*");
+                    }else if (label == 8) {
+                        // 1000 (o v v v) -> A C A A
+                        factor *= -1;
+                        tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                    }else if (label == 9) {
+                        // 1001 (o v v o) -> A C A C
+                        factor *= -1;
+                        tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3);
+                    }else if (label == 10) {
+                        // 1010 (o v o v) -> A C C A
+                        tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4);
+                    }else if (label == 11) {
+                        // 1011 (o v o o) -> A C C C
+                        factor *= -1;
+                        tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*");
+                    }else if (label == 12) {
+                        // 1100 (o o v v) -> A A A A
+                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                    }else if (label == 13) {
+                        // 1101 (o o v o) -> A A A C
+                        factor *= -1;
+                        tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
+                    }else if (label == 14) {
+                        // 1110 (o o o v) -> A A C A
+                        tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
+                    }else if (label == 15) {
+                        // 1111 (o o o o) -> A A C C
+                        tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*");
+                    }
+                    
+                    newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
+                }else {
+                
+                    std::string idx1 = "p" + std::to_string(gen_label_count++);
+                    std::string idx2 = "p" + std::to_string(gen_label_count++);
+                    std::string idx3 = "p" + std::to_string(gen_label_count++);
+                    std::string idx4 = "p" + std::to_string(gen_label_count++);
+    
+                    tmp_string.push_back(idx1+"*");
+                    tmp_string.push_back(idx2+"*");
+                    tmp_string.push_back(idx3);
+                    tmp_string.push_back(idx4);
+    
+                    newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
+                }
+            }
+    
+        }else if (op.substr(0, 1) == "t"){
+    
+            int n = std::stoi(op.substr(2));
+            std::vector<std::string> labels;
+    
+            if ( n == 0 ){
+    
+                // nothing to do
+    
+            }else {
+    
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+    
+                // excitation:
+                if ( op.substr(0,2) == "te" ) {
+    
+                    for (int id = 0; id < n; id++) {
+    
+                        std::string idx1 = "v" + std::to_string(vir_label_count++);
+                        std::string idx2 = "o" + std::to_string(occ_label_count++);
+    
+                        op_left.push_back(idx1+"*");
+                        op_right.push_back(idx2);
+    
+                        label_left.push_back(idx1);
+                        label_right.push_back(idx2);
+                    }
+                }else if ( op.substr(0,2) == "td" ) {
+    
+                    // de-excitation:
+                    for (int id = 0; id < n; id++) {
+    
+                        std::string idx1 = "v" + std::to_string(vir_label_count++);
+                        std::string idx2 = "o" + std::to_string(occ_label_count++);
+    
+                        op_left.push_back(idx2+"*");
+                        op_right.push_back(idx1);
+    
+                        // do not transpose de-excitation amplitude labels
+                        //label_left.push_back(idx1);
+                        //label_right.push_back(idx2);
+                        // transpose de-excitation amplitude labels
+                        label_left.push_back(idx2);
+                        label_right.push_back(idx1);
+                    }
+                }else {
+                    printf("\n");
+                    printf("    invalid operator type: %s\n", op.c_str());
+                    printf("\n");
+                    exit(1);
+                }
+    
+                // a*b*...
+                for (int id = 0; id < n; id++) {
+                    tmp_string.push_back(op_left[id]);
+                }
+                // op*j*...
+                for (int id = 0; id < n; id++) {
+                    tmp_string.push_back(op_right[id]);
+                }
+    
+                // tn(ab...
+                for (int id = 0; id < n; id++) {
+                    labels.push_back(label_left[id]);
+                }
+                // tn(ab......ji)
+                for (int id = n-1; id >= 0; id--) {
+                    labels.push_back(label_right[id]);
+                }
+    
+                // factor = 1/(n!)^2
+                double my_factor = 1.0;
+                for (int id = 0; id < n; id++) {
+                    my_factor *= (id+1);
+                }
+                factor *= 1.0 / my_factor / my_factor;
+            }
+    
+            int n_ph = 0;
+            if (op.size() > 3 ) {
+                if ( op.substr(3,1) == ",") {
+                    n_ph = std::stoi(op.substr(4));
+                    if ( op.substr(0,2) == "te" ) {
+                        // excitation
+                        for (int ph = 0; ph < n_ph; ph++) {
+                            newguy->is_boson_dagger.push_back(true);
+                        }
+                    }else if ( op.substr(0,2) == "td" ) {
+                        // de-excitation
+                        for (int ph = 0; ph < n_ph; ph++) {
+                            newguy->is_boson_dagger.push_back(false);
+                        }
+                    }
+                }
+            }
+            newguy->set_amplitudes('t', n, n, n_ph, labels, op_portions);
+    
+        }else if (op.substr(0, 1) == "w" || op.substr(0, 1) == "W"){ // w0 B*B
+    
+            if (op.substr(1, 1) == "0" ){
+    
+                has_w0 = true;
+    
+                newguy->is_boson_dagger.push_back(true);
+                newguy->is_boson_dagger.push_back(false);
+    
+            }else {
+                printf("\n");
+                printf("    error: only w0 is supported\n");
+                printf("\n");
+                exit(1);
+            }
+    
+        }else if (op.substr(0, 2) == "b+" || op.substr(0, 2) == "B+"){ // B*
+    
+                newguy->is_boson_dagger.push_back(true);
+    
+        }else if (op.substr(0, 2) == "b-" || op.substr(0, 2) == "B-"){ // B
+    
+                newguy->is_boson_dagger.push_back(false);
+    
+        }else if (op.substr(0, 1) == "r" || op.substr(0, 1) == "R"){
+    
+    
+            int n = std::stoi(op.substr(1));
+            int n_annihilate = n;
+            int n_create     = n;
+            std::vector<std::string> labels;
+    
+            if ( n == 0 ){
+    
+                // nothing to do
+    
+            }else {
+    
+                if ( right_operators_type == "IP" ) n_create--;
+                if ( right_operators_type == "DIP" ) n_create -= 2;
+                if ( right_operators_type == "EA" ) n_annihilate--;
+                if ( right_operators_type == "DEA" ) n_annihilate -= 2;
+    
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "v" + std::to_string(vir_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "o" + std::to_string(occ_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                // a*b*...
+                for (int id = 0; id < n_create; id++) {
+                    tmp_string.push_back(op_left[id]);
+                }
+                // ij...
+                for (int id = 0; id < n_annihilate; id++) {
+                    tmp_string.push_back(op_right[id]);
+                }
+    
+                // tn(ab...
+                for (int id = 0; id < n_create; id++) {
+                    labels.push_back(label_left[id]);
+                }
+                // tn(ab......ji)
+                for (int id = n_annihilate-1; id >= 0; id--) {
+                    labels.push_back(label_right[id]);
+                }
+    
+                // factor = 1/(n!)^2
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++) {
+                    my_factor_create *= (id+1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    my_factor_annihilate *= (id+1);
+                }
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
+            }
+    
+            int n_ph = 0;
+            if (op.size() > 2 ) {
+                if ( op.substr(2,1) == ",") {
+                    n_ph = std::stoi(op.substr(3));
+                    for (int ph = 0; ph < n_ph; ph++) {
+                        newguy->is_boson_dagger.push_back(true);
+                    }
+                }
+            }
+            newguy->set_amplitudes('r', n_create, n_annihilate, n_ph, labels, op_portions);
+    
+        }else if (op.substr(0, 1) == "l" || op.substr(0, 1) == "L"){
+    
+            int n = std::stoi(op.substr(1));
+            int n_annihilate = n;
+            int n_create     = n;
+            std::vector<std::string> labels;
+    
+            if ( n == 0 ){
+    
+                // nothing to do
+    
+            }else {
+                
+                if ( left_operators_type == "IP" ) n_annihilate--;
+                if ( left_operators_type == "DIP" ) n_annihilate -= 2;
+                if ( left_operators_type == "EA" ) n_create--;
+                if ( left_operators_type == "DEA" ) n_create -= 2;
+    
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "o" + std::to_string(occ_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "v" + std::to_string(vir_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                // op*j*...
+                for (int id = 0; id < n_create; id++) {
+                    tmp_string.push_back(op_left[id]);
+                }
+                // ab...
+                for (int id = 0; id < n_annihilate; id++) {
+                    tmp_string.push_back(op_right[id]);
+                }
+    
+                // tn(ij... 
+                for (int id = 0; id < n_create; id++) {
+                    labels.push_back(label_left[id]);
+                }
+                // tn(ij......ba)
+                for (int id = n_annihilate-1; id >= 0; id--) {
+                    labels.push_back(label_right[id]);
+                }
+                
+                // factor = 1/(n!)^2
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++) {
+                    my_factor_create *= (id+1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    my_factor_annihilate *= (id+1);
+                }
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
+            
+            }
+    
+            int n_ph = 0;
+            if (op.size() > 2 ) {
+                if ( op.substr(2,1) == ",") {
+                    n_ph = std::stoi(op.substr(3));
+                    for (int ph = 0; ph < n_ph; ph++) {
+                        newguy->is_boson_dagger.push_back(false);
+                    }
+                }
+            }
+            newguy->set_amplitudes('l', n_create, n_annihilate, n_ph, labels, op_portions);
+    
+        }else if (op.substr(0, 1) == "e" || op.substr(0, 1) == "E"){
+    
+    
+            if (op.substr(1, 1) == "1" ){
+    
+                // find comma
+                size_t pos = op.find(',');
+                if ( pos == std::string::npos ) {
+                    printf("\n");
+                    printf("    error in e1 operator definition\n");
+                    printf("\n");
+                    exit(1);
+                }
+                size_t len = pos - 2; 
+    
+                // index 1
+                tmp_string.push_back(op.substr(2, len) + "*");
+    
+                // index 2
+                tmp_string.push_back(op.substr(pos + 1));
+    
+            }else if (op.substr(1, 1) == "2" ){
+    
+                // count indices
+                size_t pos = 0;
+                int ncomma = 0;
+                std::vector<size_t> commas;
+                pos = op.find(',', pos + 1);
+                commas.push_back(pos);
+                while( pos != std::string::npos){
+                    pos = op.find(',', pos + 1);
+                    commas.push_back(pos);
+                    ncomma++;
+                }
+    
+                if ( ncomma != 3 ) {
+                    printf("\n");
+                    printf("    error in e2 definition\n");
+                    printf("\n");
+                    exit(1);
+                }
+    
+                tmp_string.push_back(op.substr(2, commas[0] - 2) + "*");
+                tmp_string.push_back(op.substr(commas[0] + 1, commas[1] - commas[0] - 1) + "*");
+                tmp_string.push_back(op.substr(commas[1] + 1, commas[2] - commas[1] - 1));
+                tmp_string.push_back(op.substr(commas[2] + 1));
+    
+            }else if (op.substr(1, 1) == "3" ){
+    
+                // count indices
+                size_t pos = 0;
+                int ncomma = 0;
+                std::vector<size_t> commas;
+                pos = op.find(',', pos + 1);
+                commas.push_back(pos);
+                while( pos != std::string::npos){
+                    pos = op.find(',', pos + 1);
+                    commas.push_back(pos);
+                    ncomma++;
+                }
+    
+                if ( ncomma != 5 ) {
+                    printf("\n");
+                    printf("    error in e3 definition\n");
+                    printf("\n");
+                    exit(1);
+                }
+    
+                tmp_string.push_back(op.substr(2, commas[0] - 2) + "*");
+                tmp_string.push_back(op.substr(commas[0] + 1, commas[1] - commas[0] - 1) + "*");
+                tmp_string.push_back(op.substr(commas[1] + 1, commas[2] - commas[1] - 1) + "*");
+                tmp_string.push_back(op.substr(commas[2] + 1, commas[3] - commas[2] - 1));
+                tmp_string.push_back(op.substr(commas[3] + 1, commas[4] - commas[3] - 1));
+                tmp_string.push_back(op.substr(commas[4] + 1));
+    
+            }else if (op.substr(1, 1) == "4" ){
+    
+                // count indices
+                size_t pos = 0;
+                int ncomma = 0;
+                std::vector<size_t> commas;
+                pos = op.find(',', pos + 1);
+                commas.push_back(pos);
+                while( pos != std::string::npos){
+                    pos = op.find(',', pos + 1);
+                    commas.push_back(pos);
+                    ncomma++;
+                }
+    
+                if ( ncomma != 7 ) {
+                    printf("\n");
+                    printf("    error in e4 definition\n");
+                    printf("\n");
+                    exit(1);
+                }
+    
+                tmp_string.push_back(op.substr(2, commas[0] - 2) + "*");
+                tmp_string.push_back(op.substr(commas[0] + 1, commas[1] - commas[0] - 1) + "*");
+                tmp_string.push_back(op.substr(commas[1] + 1, commas[2] - commas[1] - 1) + "*");
+                tmp_string.push_back(op.substr(commas[2] + 1, commas[3] - commas[2] - 1) + "*");
+                tmp_string.push_back(op.substr(commas[3] + 1, commas[4] - commas[3] - 1));
+                tmp_string.push_back(op.substr(commas[4] + 1, commas[5] - commas[4] - 1));
+                tmp_string.push_back(op.substr(commas[5] + 1, commas[6] - commas[5] - 1));
+                tmp_string.push_back(op.substr(commas[6] + 1));
+    
+            }else {
+                printf("\n");
+                printf("    error: only e1, e2, e3, and e4 operators are supported\n");
+                printf("\n");
+                exit(1);
+            }
+    
+        }else if (op.substr(0, 1) == "1" ) { // unit operator ... do nothing
+    
+        }else if (op.substr(0, 1) == "a" || op.substr(0, 1) == "A"){ // single creator / annihilator
+    
+    
+            if (op.substr(1, 1) == "*" ){ // creator
+    
+                tmp_string.push_back(op.substr(1) + "*");
+    
+            }else { // annihilator
+    
+                tmp_string.push_back(op.substr(1));
+    
+            }
+    
+        }else {
+                printf("\n");
+                printf("    error: undefined string: %s\n", op.c_str());
+                printf("\n");
+                exit(1);
+        }
+    }
+    
+    newguy->factor = factor;
+    
+    for (const std::string & op : tmp_string) {
+        newguy->string.push_back(op);
+    }
+    
+    newguy->has_w0 = has_w0;
+    
+    // make sure factor > 0
+    if ( newguy->factor < 0.0 ) {
+        newguy->factor = fabs(newguy->factor);
+        newguy->sign *= -1;
+    }
+    return newguy;
 }
 
 void pq_helper::simplify() {

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -42,6 +42,7 @@
 #include "pq_add_label_ranges.h"
 #include "pq_add_spin_labels.h"
 #include "pq_cumulant_expansion.h"
+#include "pq_swap_operators.h"
 #include "../pq_graph/include/pq_graph.h"
 
 namespace py = pybind11;
@@ -758,39 +759,6 @@ void pq_helper::process_operator_products(std::vector<pq_operator_terms> ops) {
         ops = new_ops;
     }while(!done_processing);
 
-    if (is_hamiltonian_normal_ordered) {
-        // TODO: normal order 'j2' and drop 'j1' 
-        // TODO: normal order 'f' 
-        printf("\n");
-        printf("    error: the normal ordered hamiltonian operators are broken\n");
-        printf("\n");
-        exit(1);
-    }
-
-    // normal order the central operator, if desired
-    /*if (is_central_operator_normal_ordered) {
-
-        std::vector<std::vector<std::string> save_left_operators;
-        for (const std::vector<std::string> & ops : left_operators) {
-            save_left_operators.push_back(ops);
-        }
-
-        std::vector<std::vector<std::string> save_right_operators;
-        for (const std::vector<std::string> & ops : right_operators) {
-            save_right_operators.push_back(ops);
-        }
-
-        left_operators.clear();
-        right_operators.clear();
-
-        for (const std::vector<std::string> & ops : save_left_operators) {
-            left_operators.push_back(ops);
-        }
-        for (const std::vector<std::string> & ops : save_right_operators) {
-            left_operators.push_back(ops);
-        }
-    }*/
-
     for (auto op : ops){
         add_operator_product(op.factor, op.operators);
     }
@@ -806,7 +774,7 @@ void pq_helper::py_add_operator_product(double factor, std::vector<std::string> 
 // add a string of operators
 void pq_helper::add_operator_product(double factor, std::vector<std::string>  in){
 
-    // apply any extra operators on left or right:
+    // make sure left / right operator lists aren't empty
     if ( (int)left_operators.size() == 0 ) {
         std::vector<std::string> junk;
         junk.emplace_back("1");
@@ -818,19 +786,84 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
         right_operators.push_back(junk);
     }
 
+/*
+    int o_count_1 = 0;
+    int v_count_1 = 0;
+    std::vector<std::shared_ptr<pq_string>> center_strings = build_new_strings(1.0, in, o_count_1, v_count_1);
+
+    // bring pq_strings to normal order
+    std::vector<std::shared_ptr<pq_string>> ordered_center_strings;
+    if (vacuum == "TRUE") {
+        add_new_string_true_vacuum(center_strings, ordered_center_strings, print_level, find_paired_permutations, true);
+    } else {
+        add_new_string_fermi_vacuum(center_strings, ordered_center_strings, print_level, find_paired_permutations, true);
+    }
+*/
+
     for (std::vector<std::string> & left_operator : left_operators) {
+
+/*
+        int o_count_2 = o_count_1;
+        int v_count_2 = v_count_1;
+        std::vector<std::shared_ptr<pq_string>> left_strings = build_new_strings(1.0, left_operator, o_count_2, v_count_2);
+*/
+
         for (std::vector<std::string> & right_operator : right_operators) {
 
-            // build pq_strings
-            int occ_label_count = 0;
-            int vir_label_count = 0;
-            std::vector<std::shared_ptr<pq_string>> new_pq_strings = build_new_strings(factor, left_operator, in, right_operator, occ_label_count, vir_label_count);
+/*
+            int o_count_3 = o_count_2;
+            int v_count_3 = v_count_2;
+            std::vector<std::shared_ptr<pq_string>> right_strings = build_new_strings(1.0, right_operator, o_count_3, v_count_3);
+*/
+
+            int o_count = 0;
+            int v_count = 0;
+            std::vector<std::shared_ptr<pq_string>> left_strings = build_new_strings(1.0, left_operator, o_count, v_count);
+            std::vector<std::shared_ptr<pq_string>> center_strings = build_new_strings(1.0, in, o_count, v_count);
+            std::vector<std::shared_ptr<pq_string>> right_strings = build_new_strings(1.0, right_operator, o_count, v_count);
+
+/*
+            for (auto & pq_str: center_strings) {
+                bool done_rearranging = false;
+                do {
+                    done_rearranging = true;
+                    bool am_i_done = swap_operators_fermi_vacuum_no_deltas(pq_str);
+
+                    if ( !am_i_done ) done_rearranging = false;
+                }while(!done_rearranging);
+            }
+*/
+
+            // sandwich pq_strings together
+            std::vector<std::shared_ptr<pq_string>> new_pq_strings;
+            for (auto & left: left_strings){
+                for (auto & right: right_strings){
+                    for (auto & center: center_strings){
+
+                        // is the center bit fully contracted?
+                        if ( center->symbol.size() == 0 && center->is_boson_dagger.size() == 0 ) {
+                            continue;
+                        }
+
+                        std::shared_ptr<pq_string> newguy (new pq_string(vacuum));
+
+                        newguy->append(left.get());
+                        newguy->append(center.get());
+                        newguy->append(right.get());
+
+                        newguy->factor *= factor;
+
+                        new_pq_strings.push_back(newguy);
+
+                    }
+                }
+            }
 
             // bring pq_strings to normal order
             if (vacuum == "TRUE") {
-                add_new_string_true_vacuum(new_pq_strings, ordered, print_level, find_paired_permutations);
+                add_new_string_true_vacuum(new_pq_strings, ordered, print_level, find_paired_permutations, false);
             } else {
-                add_new_string_fermi_vacuum(new_pq_strings, ordered, print_level, find_paired_permutations, occ_label_count, vir_label_count);
+                add_new_string_fermi_vacuum(new_pq_strings, ordered, print_level, find_paired_permutations, false);
             }
         }
     }
@@ -838,9 +871,7 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
 
 // build a pq_string from the string representations of operators
 std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double factor, 
-    std::vector<std::string> left_op, 
-    std::vector<std::string> central_op, 
-    std::vector<std::string> right_op,
+    std::vector<std::string> input_op, 
     int & occ_label_count,
     int & vir_label_count){
 
@@ -848,22 +879,11 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
     
     std::vector<std::string> tmp_string;
     
-    bool has_w0       = false;
-    
-    occ_label_count = 0;
-    vir_label_count = 0;
+    bool has_w0 = false;
+
     int gen_label_count = 0;
- 
-    // apply any extra operators on left or right:
-    std::vector<std::string> tmp = left_op;
-    for (const std::string & op : central_op) {
-        tmp.push_back(op);
-    }
-    for (const std::string & op : right_op) {
-        tmp.push_back(op);
-    }
     
-    for (std::string & op_including_portions : tmp) {
+    for (std::string & op_including_portions : input_op) {
     
         // bernoulli expansion requires operator portion specification. split into base name and portion
         std::string op = get_operator_base_name(op_including_portions);
@@ -898,53 +918,13 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
     
         }else if (op.substr(0, 1) == "f" || op.substr(0, 1) == "F") { // fock operator
     
-            if ( is_hamiltonian_normal_ordered ) {
+            std::string idx1 = "p" + std::to_string(gen_label_count++);
+            std::string idx2 = "p" + std::to_string(gen_label_count++);
     
-                // find number in string representing which block of F this is
-                std::string num_str;
-                size_t pos = op.find('{', 1); // start in position 1
-                if (pos != std::string::npos) {
-                    num_str = op.substr(1, pos - 1);
-                } else {
-                    num_str = op.substr(1);
-                }
-                int label = std::stoi(num_str);
+            tmp_string.push_back(idx1+"*"); 
+            tmp_string.push_back(idx2);
     
-                // Map the bits of 'label' (0 to 3) to 'o' (occupied) or 'v' (virtual)
-                // label & 2 checks the first index, label & 1 checks the second
-                std::string idx1 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                std::string idx2 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                
-                // Normal ordering: pushing true creators (C) left of true annihilators (A)
-                if (label == 0) {
-                    // 00 (v v) -> C A -> Already normal ordered
-                    tmp_string.push_back(idx1+"*"); 
-                    tmp_string.push_back(idx2);
-                }else if (label == 1) {
-                    // 01 (v o) -> C C -> Already normal ordered (preserve relative order)
-                    tmp_string.push_back(idx1+"*"); 
-                    tmp_string.push_back(idx2);
-                }else if (label == 2) {
-                    // 10 (o v) -> A A -> Already normal ordered (preserve relative order)
-                    tmp_string.push_back(idx1+"*"); 
-                    tmp_string.push_back(idx2);
-                }else if (label == 3) {
-                    // 11 (o o) -> A C -> Swap needed to put C before A
-                    factor *= -1;
-                    tmp_string.push_back(idx2); 
-                    tmp_string.push_back(idx1+"*");
-                }
-    
-                newguy->set_integrals("fock", {idx1, idx2}, op_portions);
-            }else {
-                std::string idx1 = "p" + std::to_string(gen_label_count++);
-                std::string idx2 = "p" + std::to_string(gen_label_count++);
-    
-                tmp_string.push_back(idx1+"*"); 
-                tmp_string.push_back(idx2);
-    
-                newguy->set_integrals("fock", {idx1, idx2}, op_portions);
-            }
+            newguy->set_integrals("fock", {idx1, idx2}, op_portions);
     
         }else if (op.substr(0, 2) == "d+" || op.substr(0, 2) == "D+") { // one-electron operator (dipole + boson creator)
     
@@ -1000,15 +980,6 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
     
             if (op.substr(1, 1) == "1" ){
     
-                // no contribution from -<pi||qi> p*q if hamiltonian is normal ordered
-                if ( is_hamiltonian_normal_ordered ) {
-                    printf("\n");
-                    printf("    normal ordered hamiltonian is broken\n");
-                    printf("\n");
-                    exit(1);
-                    //return newguy;
-                }
-    
                 factor *= -1.0;
     
                 std::string idx1 = "p" + std::to_string(gen_label_count++);
@@ -1027,97 +998,17 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
     
                 factor *= 0.25;
     
-                if ( is_hamiltonian_normal_ordered ) {
+                std::string idx1 = "p" + std::to_string(gen_label_count++);
+                std::string idx2 = "p" + std::to_string(gen_label_count++);
+                std::string idx3 = "p" + std::to_string(gen_label_count++);
+                std::string idx4 = "p" + std::to_string(gen_label_count++);
     
-                    // find number in string representing which block of V (J2) this is
-                    std::string num_str;
-                    size_t pos = op.find('{', 2); // start in index 2
-                    if (pos != std::string::npos) {
-                        num_str = op.substr(2, pos - 2);
-                    } else {
-                        num_str = op.substr(2);
-                    }
-                    int label = std::stoi(num_str);
+                tmp_string.push_back(idx1+"*");
+                tmp_string.push_back(idx2+"*");
+                tmp_string.push_back(idx3);
+                tmp_string.push_back(idx4);
     
-                    // Check the bits of 'label' to assign 'o' (occupied) or 'v' (virtual) 
-                    // and increment the correct counter on the fly.
-                    std::string idx1 = (label & 8) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                    std::string idx2 = (label & 4) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                    std::string idx3 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-                    std::string idx4 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
-    
-                    // Normal ordering: pushing true creators (C) to the left of true annihilators (A)
-                    if (label == 0) {
-                        // 0000 (v v v v) -> C C A A
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                    }else if (label == 1) {
-                        // 0001 (v v v o) -> C C A C
-                        factor *= -1;
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx3);
-                    }else if (label == 2) {
-                        // 0010 (v v o v) -> C C C A
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                    }else if (label == 3) {
-                        // 0011 (v v o o) -> C C C C
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                    }else if (label == 4) {
-                        // 0100 (v o v v) -> C A A A
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                    }else if (label == 5) {
-                        // 0101 (v o v o) -> C A A C
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
-                    }else if (label == 6) {
-                        // 0110 (v o o v) -> C A C A
-                        factor *= -1;
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
-                    }else if (label == 7) {
-                        // 0111 (v o o o) -> C A C C
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*");
-                    }else if (label == 8) {
-                        // 1000 (o v v v) -> A C A A
-                        factor *= -1;
-                        tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                    }else if (label == 9) {
-                        // 1001 (o v v o) -> A C A C
-                        factor *= -1;
-                        tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3);
-                    }else if (label == 10) {
-                        // 1010 (o v o v) -> A C C A
-                        tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4);
-                    }else if (label == 11) {
-                        // 1011 (o v o o) -> A C C C
-                        factor *= -1;
-                        tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*");
-                    }else if (label == 12) {
-                        // 1100 (o o v v) -> A A A A
-                        tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
-                    }else if (label == 13) {
-                        // 1101 (o o v o) -> A A A C
-                        factor *= -1;
-                        tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
-                    }else if (label == 14) {
-                        // 1110 (o o o v) -> A A C A
-                        tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
-                    }else if (label == 15) {
-                        // 1111 (o o o o) -> A A C C
-                        tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*");
-                    }
-                    
-                    newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
-                }else {
-                
-                    std::string idx1 = "p" + std::to_string(gen_label_count++);
-                    std::string idx2 = "p" + std::to_string(gen_label_count++);
-                    std::string idx3 = "p" + std::to_string(gen_label_count++);
-                    std::string idx4 = "p" + std::to_string(gen_label_count++);
-    
-                    tmp_string.push_back(idx1+"*");
-                    tmp_string.push_back(idx2+"*");
-                    tmp_string.push_back(idx3);
-                    tmp_string.push_back(idx4);
-    
-                    newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
-                }
+                newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
             }
     
         }else if (op.substr(0, 1) == "t"){
@@ -1564,9 +1455,9 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 for (std::shared_ptr<pq_string> & pq_str : list) {
                     new_pq_strings.push_back(pq_str);
                 }
-                occ_label_count++;
-                vir_label_count++;
             }
+            occ_label_count++;
+            vir_label_count++;
         }while(!done_expanding);
     }
 

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -824,20 +824,20 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
             // build pq_strings
             int occ_label_count = 0;
             int vir_label_count = 0;
-            std::shared_ptr<pq_string> newguy = build_new_string(factor, left_operator, in, right_operator, occ_label_count, vir_label_count);
+            std::vector<std::shared_ptr<pq_string>> new_pq_strings = build_new_strings(factor, left_operator, in, right_operator, occ_label_count, vir_label_count);
 
             // bring pq_strings to normal order
             if (vacuum == "TRUE") {
-                add_new_string_true_vacuum(newguy, ordered, print_level, find_paired_permutations);
+                add_new_string_true_vacuum(new_pq_strings, ordered, print_level, find_paired_permutations);
             } else {
-                add_new_string_fermi_vacuum(newguy, ordered, print_level, find_paired_permutations, occ_label_count, vir_label_count);
+                add_new_string_fermi_vacuum(new_pq_strings, ordered, print_level, find_paired_permutations, occ_label_count, vir_label_count);
             }
         }
     }
 }
 
 // build a pq_string from the string representations of operators
-std::shared_ptr<pq_string> pq_helper::build_new_string(double factor, 
+std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double factor, 
     std::vector<std::string> left_op, 
     std::vector<std::string> central_op, 
     std::vector<std::string> right_op,
@@ -853,7 +853,7 @@ std::shared_ptr<pq_string> pq_helper::build_new_string(double factor,
     occ_label_count = 0;
     vir_label_count = 0;
     int gen_label_count = 0;
-    
+ 
     // apply any extra operators on left or right:
     std::vector<std::string> tmp = left_op;
     for (const std::string & op : central_op) {
@@ -1006,7 +1006,7 @@ std::shared_ptr<pq_string> pq_helper::build_new_string(double factor,
                     printf("    normal ordered hamiltonian is broken\n");
                     printf("\n");
                     exit(1);
-                    return newguy;
+                    //return newguy;
                 }
     
                 factor *= -1.0;
@@ -1540,7 +1540,92 @@ std::shared_ptr<pq_string> pq_helper::build_new_string(double factor,
         newguy->factor = fabs(newguy->factor);
         newguy->sign *= -1;
     }
-    return newguy;
+
+    // two more steps before we have proper pq_string objects
+    // 1. expand general labels (fermi vacuum)
+    // 2. convert "string" to "symbol", "is_dagger", and "is_dagger_fermi"
+
+    std::vector< std::shared_ptr<pq_string> > new_pq_strings;
+    new_pq_strings.push_back(newguy);
+
+    // expand general labels (fermi vacuum)
+    if (vacuum != "TRUE") {
+        
+        bool done_expanding = false;
+        do {
+            std::vector< std::shared_ptr<pq_string> > list;
+            done_expanding = true;
+            for (const std::shared_ptr<pq_string> & pq_str : new_pq_strings) {
+                bool am_i_done = expand_general_labels(pq_str, list, occ_label_count, vir_label_count);
+                if ( !am_i_done ) done_expanding = false;
+            }
+            if (!done_expanding) {
+                new_pq_strings.clear();
+                for (std::shared_ptr<pq_string> & pq_str : list) {
+                    new_pq_strings.push_back(pq_str);
+                }
+                occ_label_count++;
+                vir_label_count++;
+            }
+        }while(!done_expanding);
+    }
+
+    // now, we need to convert the list "new_pq_strings[i]->string" into symbols and daggers
+    if (vacuum == "TRUE") {
+        for (auto & my_string: new_pq_strings ) {
+            for (size_t i = 0; i < my_string->string.size(); i++) {
+                std::string me = my_string->string[i];
+                if ( me.find('*') != std::string::npos ) {
+                    removeStar(me);
+                    my_string->is_dagger.push_back(true);
+                }else {
+                    my_string->is_dagger.push_back(false);
+                }
+                my_string->symbol.push_back(me);
+            }
+        }
+    }else {
+        for (auto & my_string: new_pq_strings ) {
+            for (size_t i = 0; i < my_string->string.size(); i++) {
+                std::string me = my_string->string[i];
+
+                std::string me_nostar = me;
+                if (me_nostar.find('*') != std::string::npos ){
+                    removeStar(me_nostar);
+                }
+
+                if ( is_vir(me_nostar) ) {
+                    if (me.find('*') != std::string::npos ){
+                        my_string->is_dagger.push_back(true);
+                        my_string->is_dagger_fermi.push_back(true);
+                    }else {
+                        my_string->is_dagger.push_back(false);
+                        my_string->is_dagger_fermi.push_back(false);
+                    }
+                    my_string->symbol.push_back(me_nostar);
+                }else if ( is_occ(me_nostar) ) {
+                    if (me.find('*') != std::string::npos ){
+                        my_string->is_dagger.push_back(true);
+                        my_string->is_dagger_fermi.push_back(false);
+                    }else {
+                        my_string->is_dagger.push_back(false);
+                        my_string->is_dagger_fermi.push_back(true);
+                    }
+                    my_string->symbol.push_back(me_nostar);
+                }
+            }
+        }
+    }
+
+    // make sure all factors are non-negative
+    for (auto & my_string: new_pq_strings ) {
+        if ( my_string->factor < 0.0 ) {
+            my_string->sign *= -1;
+            my_string->factor = fabs(my_string->factor);
+        }
+    }
+
+    return new_pq_strings;
 }
 
 void pq_helper::simplify() {

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -54,6 +54,7 @@ void export_pq_helper(py::module& m) {
         .def(py::init< std::string >())
         .def("set_print_level", &pq_helper::set_print_level)
         .def("set_unitary_cc", &pq_helper::set_unitary_cc)
+        .def("set_hamiltonian_normal_ordered", &pq_helper::set_hamiltonian_normal_ordered)
         .def("set_bernoulli_excitation_level", &pq_helper::set_bernoulli_excitation_level)
         .def("set_left_operators", &pq_helper::set_left_operators)
         .def("set_right_operators", &pq_helper::set_right_operators)
@@ -134,10 +135,6 @@ void export_pq_helper(py::module& m) {
         .def("add_hextuple_commutator", &pq_helper::add_hextuple_commutator)
         .def("add_operator_product", &pq_helper::add_operator_product);
 
-    //py::class_<pdaggerq::pq_operator_terms, std::shared_ptr<pdaggerq::pq_operator_terms> >(m, "pq_operator_terms")
-    //    .def(py::init< double, std::vector<std::string> >())
-    //    .def("factor", &pq_operator_terms::factor)
-    //    .def("operators", &pq_operator_terms::operators);
     py::class_<pdaggerq::pq_operator_terms>(m, "pq_operator_terms")
         .def(py::init<double, std::vector<std::string>>())
         .def("factor", &pq_operator_terms::get_factor)
@@ -278,6 +275,11 @@ void pq_helper::set_right_operators_type(const std::string &type) {
         printf("\n");
         exit(1);
     }
+}
+
+// use the normal ordered form of the hamiltonian operator? default false
+void pq_helper::set_hamiltonian_normal_ordered(bool is_normal_ordered) {
+    is_hamiltonian_normal_ordered = is_normal_ordered;
 }
 
 // is the cluster operator antihermitian for ucc? default false
@@ -644,34 +646,91 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
         // get bernoulli operator portions
         std::string op_portions = get_operator_portions_as_string(in[count]);
 
-        // term 1
-        std::string v_type = "j1";
-        if ( op_portions.length() > 0 ) { 
-            v_type += "{" + op_portions + "}";
-        }
-        tmp_in.emplace_back(v_type);
-        for (int i = count+1; i < (int)in.size(); i++) {
-            tmp_in.push_back(in[i]);
-        }
-        in.clear();
-        for (const auto & op : tmp_in) {
-            in.push_back(op);
-        }
-        add_operator_product(factor, in);
+        if ( !is_hamiltonian_normal_ordered ) {
+            // term 1
+            std::string v_type = "j1";
+            if ( op_portions.length() > 0 ) { 
+                v_type += "{" + op_portions + "}";
+            }
+            tmp_in.emplace_back(v_type);
+            for (int i = count+1; i < (int)in.size(); i++) {
+                tmp_in.push_back(in[i]);
+            }
+            in.clear();
+            for (const auto & op : tmp_in) {
+                in.push_back(op);
+            }
+            add_operator_product(factor, in);
 
-        // term 2
-        in.clear();
-        for (int i = 0; i < count; i++) {
-            in.push_back(tmp_in[i]);
+            // term 2
+            in.clear();
+            for (int i = 0; i < count; i++) {
+                in.push_back(tmp_in[i]);
+            }
+            v_type[1] = '2';
+            in.emplace_back(v_type);
+            for (int i = count + 1; i < (int)tmp_in.size(); i++) {
+                in.push_back(tmp_in[i]);
+            }
+            add_operator_product(factor, in);
+        }else {
+            for (int label = 0; label < 16; label++) {
+                std::vector<std::string> my_in;
+                for (int i = 0; i < count; i++) {
+                    my_in.push_back(in[i]);
+                }
+                // only term 2 (16 times...)
+                std::string v_type = "j2" + std::to_string(label);
+                if ( op_portions.length() > 0 ) { 
+                    v_type += "{" + op_portions + "}";
+                }
+                my_in.push_back(v_type);
+                for (int i = count+1; i < (int)in.size(); i++) {
+                    my_in.push_back(in[i]);
+                }
+                in.clear();
+                for (const auto & op : my_in) {
+                    in.push_back(op);
+                }
+                add_operator_product(factor, in);
+            }
         }
-        v_type[1] = '2';
-        in.emplace_back(v_type);
-        for (int i = count + 1; i < (int)tmp_in.size(); i++) {
-            in.push_back(tmp_in[i]);
-        }
-        add_operator_product(factor, in);
-        
         return;
+    }
+
+    count = 0;
+    bool found_f = false;
+    for (const std::string & op : in) {
+        if (op == "f" || op == "F") {
+            found_f = true;
+            break;
+        }else {
+            count++;
+        }
+    }
+    if ( found_f ) {
+        if ( !is_hamiltonian_normal_ordered ) {
+            // do nothing
+        }else {
+            // add each block of F separately, Fvv, Fvo, Fov, Foo
+            for (int label = 0; label < 4; label++) {
+                std::vector<std::string> my_in;
+                for (int i = 0; i < count; i++) {
+                    my_in.push_back(in[i]);
+                }
+                // 4 blocks
+                my_in.push_back('f' + std::to_string(label));
+                for (int i = count+1; i < (int)in.size(); i++) {
+                    my_in.push_back(in[i]);
+                }
+                in.clear();
+                for (const auto & op : my_in) {
+                    in.push_back(op);
+                }
+                add_operator_product(factor, in);
+            }
+            return;
+        }
     }
 
     // now check for t and add de-excitation operators if doing unitary cc
@@ -816,17 +875,55 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
 
                 }else if (op.substr(0, 1) == "f" || op.substr(0, 1) == "F") { // fock operator
 
-                    std::string idx1 = "p" + std::to_string(gen_label_count++);
-                    std::string idx2 = "p" + std::to_string(gen_label_count++);
+                    if ( is_hamiltonian_normal_ordered ) {
 
-                    // index 1
-                    tmp_string.push_back(idx1+"*");
+                        // find number in string representing which block of F this is
+                        std::string num_str;
+                        size_t pos = op.find('{', 1); // start in position 1
+                        if (pos != std::string::npos) {
+                            num_str = op.substr(1, pos - 1);
+                        } else {
+                            num_str = op.substr(1);
+                        }
+                        int label = std::stoi(num_str);
 
-                    // index 2
-                    tmp_string.push_back(idx2);
+                        // Map the bits of 'label' (0 to 3) to 'o' (occupied) or 'v' (virtual)
+                        // label & 2 checks the first index, label & 1 checks the second
+                        std::string idx1 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                        std::string idx2 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                        
+                        // Normal ordering: pushing true creators (C) left of true annihilators (A)
+                        if (label == 0) {
+                            // 00 (v v) -> C A -> Already normal ordered
+                            tmp_string.push_back(idx1+"*"); 
+                            tmp_string.push_back(idx2);
+                        }else if (label == 1) {
+                            // 01 (v o) -> C C -> Already normal ordered (preserve relative order)
+                            tmp_string.push_back(idx1+"*"); 
+                            tmp_string.push_back(idx2);
+                        }else if (label == 2) {
+                            // 10 (o v) -> A A -> Already normal ordered (preserve relative order)
+                            tmp_string.push_back(idx1+"*"); 
+                            tmp_string.push_back(idx2);
+                        }else if (label == 3) {
+                            // 11 (o o) -> A C -> Swap needed to put C before A
+                            factor *= -1;
+                            tmp_string.push_back(idx2); 
+                            tmp_string.push_back(idx1+"*");
+                        }
 
-                    // integrals
-                    newguy->set_integrals("fock", {idx1, idx2}, op_portions);
+                        newguy->set_integrals("fock", {idx1, idx2}, op_portions);
+                    }else {
+                        std::string idx1 = "p" + std::to_string(gen_label_count++);
+                        std::string idx2 = "p" + std::to_string(gen_label_count++);
+
+                        tmp_string.push_back(idx1+"*"); 
+                        tmp_string.push_back(idx2);
+
+                        newguy->set_integrals("fock", {idx1, idx2}, op_portions);
+                    }
+
+
 
                 }else if (op.substr(0, 2) == "d+" || op.substr(0, 2) == "D+") { // one-electron operator (dipole + boson creator)
 
@@ -882,6 +979,11 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
 
                     if (op.substr(1, 1) == "1" ){
 
+                        // no contribution from -<pi||qi> p*q if hamiltonian is normal ordered
+                        if ( is_hamiltonian_normal_ordered ) {
+                            return;
+                        }
+
                         factor *= -1.0;
 
                         std::string idx1 = "p" + std::to_string(gen_label_count++);
@@ -900,18 +1002,97 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
 
                         factor *= 0.25;
 
-                        std::string idx1 = "p" + std::to_string(gen_label_count++);
-                        std::string idx2 = "p" + std::to_string(gen_label_count++);
-                        std::string idx3 = "p" + std::to_string(gen_label_count++);
-                        std::string idx4 = "p" + std::to_string(gen_label_count++);
+                        if ( is_hamiltonian_normal_ordered ) {
 
-                        tmp_string.push_back(idx1+"*");
-                        tmp_string.push_back(idx2+"*");
-                        tmp_string.push_back(idx3);
-                        tmp_string.push_back(idx4);
+                            // find number in string representing which block of V (J2) this is
+                            std::string num_str;
+                            size_t pos = op.find('{', 2); // start in index 2
+                            if (pos != std::string::npos) {
+                                num_str = op.substr(2, pos - 2);
+                            } else {
+                                num_str = op.substr(2);
+                            }
+                            int label = std::stoi(num_str);
 
-                        newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
+                            // Check the bits of 'label' to assign 'o' (occupied) or 'v' (virtual) 
+                            // and increment the correct counter on the fly.
+                            std::string idx1 = (label & 8) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                            std::string idx2 = (label & 4) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                            std::string idx3 = (label & 2) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
+                            std::string idx4 = (label & 1) ? "o" + std::to_string(occ_label_count++) : "v" + std::to_string(vir_label_count++);
 
+                            // Normal ordering: pushing true creators (C) to the left of true annihilators (A)
+                            if (label == 0) {
+                                // 0000 (v v v v) -> C C A A
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                            }else if (label == 1) {
+                                // 0001 (v v v o) -> C C A C
+                                factor *= -1;
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx3);
+                            }else if (label == 2) {
+                                // 0010 (v v o v) -> C C C A
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                            }else if (label == 3) {
+                                // 0011 (v v o o) -> C C C C
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                            }else if (label == 4) {
+                                // 0100 (v o v v) -> C A A A
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                            }else if (label == 5) {
+                                // 0101 (v o v o) -> C A A C
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
+                            }else if (label == 6) {
+                                // 0110 (v o o v) -> C A C A
+                                factor *= -1;
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
+                            }else if (label == 7) {
+                                // 0111 (v o o o) -> C A C C
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx2+"*");
+                            }else if (label == 8) {
+                                // 1000 (o v v v) -> A C A A
+                                factor *= -1;
+                                tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                            }else if (label == 9) {
+                                // 1001 (o v v o) -> A C A C
+                                factor *= -1;
+                                tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx3);
+                            }else if (label == 10) {
+                                // 1010 (o v o v) -> A C C A
+                                tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx4);
+                            }else if (label == 11) {
+                                // 1011 (o v o o) -> A C C C
+                                factor *= -1;
+                                tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*");
+                            }else if (label == 12) {
+                                // 1100 (o o v v) -> A A A A
+                                tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3); tmp_string.push_back(idx4);
+                            }else if (label == 13) {
+                                // 1101 (o o v o) -> A A A C
+                                factor *= -1;
+                                tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx3);
+                            }else if (label == 14) {
+                                // 1110 (o o o v) -> A A C A
+                                tmp_string.push_back(idx3); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*"); tmp_string.push_back(idx4);
+                            }else if (label == 15) {
+                                // 1111 (o o o o) -> A A C C
+                                tmp_string.push_back(idx3); tmp_string.push_back(idx4); tmp_string.push_back(idx1+"*"); tmp_string.push_back(idx2+"*");
+                            }
+                            
+                            newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
+                        }else {
+                        
+                            std::string idx1 = "p" + std::to_string(gen_label_count++);
+                            std::string idx2 = "p" + std::to_string(gen_label_count++);
+                            std::string idx3 = "p" + std::to_string(gen_label_count++);
+                            std::string idx4 = "p" + std::to_string(gen_label_count++);
+
+                            tmp_string.push_back(idx1+"*");
+                            tmp_string.push_back(idx2+"*");
+                            tmp_string.push_back(idx3);
+                            tmp_string.push_back(idx4);
+
+                            newguy->set_integrals("eri", {idx1, idx2, idx4, idx3}, op_portions);
+                        }
                     }
 
                 }else if (op.substr(0, 1) == "t"){
@@ -1315,7 +1496,7 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
 
                 }else {
                         printf("\n");
-                        printf("    error: undefined string\n");
+                        printf("    error: undefined string: %s\n", op.c_str());
                         printf("\n");
                         exit(1);
                 }

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -258,7 +258,7 @@ class pq_helper {
      * @param vir_label_count: how many virtual labels in the pq_string?
      *
      */
-    std::shared_ptr<pq_string> build_new_string(double factor, 
+    std::vector<std::shared_ptr<pq_string>> build_new_strings(double factor, 
         std::vector<std::string> left_op, 
         std::vector<std::string> central_op, 
         std::vector<std::string> right_op,

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -182,6 +182,15 @@ class pq_helper {
 
     /**
      *
+     * set whether or not we use the normal-ordered form of the hamiltonian
+     *
+     * @param is_normal_ordered: true/false
+     *
+     */
+    void set_hamiltonian_normal_ordered(bool is_normal_ordered);
+
+    /**
+     *
      * set whether or not the cluster operator is antihermitian for UCC
      *
      * @param is_unitary: true/false
@@ -643,6 +652,13 @@ private:
      *
      */
     bool find_paired_permutations;
+
+    /** 
+     * 
+     * use the normal-ordered form of the hamiltonian? 
+     * 
+     */
+    bool is_hamiltonian_normal_ordered = false;
 
     /** 
      * 

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -284,13 +284,24 @@ class pq_helper {
 
     /**
      *
-     * check if there are fluctuation potential operators that needs to
+     * check if there are fluctuation potential operators that need to
      * be split into multiple terms
      *
      * @param ops: a list of pq_operator_terms
      *
      */
     std::pair<bool,std::vector<pq_operator_terms>> process_fluctuation_potential(std::vector<pq_operator_terms> ops_in);
+
+
+    /**
+     *
+     * check if there are normal-ordered foc operators that need to
+     * be split into multiple terms
+     *
+     * @param ops: a list of pq_operator_terms
+     *
+     */
+    std::pair<bool,std::vector<pq_operator_terms>> process_fock_operator(std::vector<pq_operator_terms> ops_in);
 
     /**
      *

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -251,21 +251,15 @@ class pq_helper {
      * build a pq_string from the string representations of operators
      *
      * @param factor: the numerical factor associated with the operator product
-     * @param left_op: a list of strings defining the bra
-     * @param central_op: a list of strings defining the central operator product
-     * @param right_op: a list of strings defining the ket
+     * @param input_op: a list of strings defining the operator product
      * @param occ_label_count: how many occupied labels in the pq_string?
      * @param vir_label_count: how many virtual labels in the pq_string?
      *
      */
     std::vector<std::shared_ptr<pq_string>> build_new_strings(double factor, 
-        std::vector<std::string> left_op, 
-        std::vector<std::string> central_op, 
-        std::vector<std::string> right_op,
+        std::vector<std::string> input_op, 
         int & occ_label_count,
         int & vir_label_count);
-
-
 
     /**
      *

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -248,6 +248,27 @@ class pq_helper {
 
     /**
      *
+     * build a pq_string from the string representations of operators
+     *
+     * @param factor: the numerical factor associated with the operator product
+     * @param left_op: a list of strings defining the bra
+     * @param central_op: a list of strings defining the central operator product
+     * @param right_op: a list of strings defining the ket
+     * @param occ_label_count: how many occupied labels in the pq_string?
+     * @param vir_label_count: how many virtual labels in the pq_string?
+     *
+     */
+    std::shared_ptr<pq_string> build_new_string(double factor, 
+        std::vector<std::string> left_op, 
+        std::vector<std::string> central_op, 
+        std::vector<std::string> right_op,
+        int & occ_label_count,
+        int & vir_label_count);
+
+
+
+    /**
+     *
      * python wrapper for calling add_operator_product() to 
      * add a product of operators (i.e., {'h','t1'} )
      *

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -238,10 +238,32 @@ class pq_helper {
      *
      * add a product of operators (i.e., {'h','t1'} )
      *
+     * @param factor: the numerical factor associated with the operator product
      * @param in: a list of strings defining the operator product
      *
      */
     void add_operator_product(double factor, std::vector<std::string> in);
+
+    /**
+     *
+     * python wrapper for calling add_operator_product() to 
+     * add a product of operators (i.e., {'h','t1'} )
+     *
+     * @param factor: the numerical factor associated with the operator product
+     * @param in: a list of strings defining the operator product
+     *
+     */
+    void py_add_operator_product(double factor, std::vector<std::string>  in);
+
+    /**
+     *
+     * process a list of operator products, expanding the list where 
+     * necessary, e.g., 't1' -> 'te1' - 'td1', 'v' -> 'j1' + 'j2', etc.
+     *
+     * @param in: a list of pq_operator_terms
+     *
+     */
+    void process_operator_products(std::vector<pq_operator_terms> ops);
 
     /**
      *

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -26,6 +26,8 @@
 
 #include "pq_string.h"
 
+#include <utility>
+
 namespace pdaggerq {
 
 class pq_operator_terms {
@@ -264,6 +266,27 @@ class pq_helper {
      *
      */
     void process_operator_products(std::vector<pq_operator_terms> ops);
+
+    /**
+     *
+     * check if there are fluctuation potential operators that needs to
+     * be split into multiple terms
+     *
+     * @param ops: a list of pq_operator_terms
+     *
+     */
+    std::pair<bool,std::vector<pq_operator_terms>> process_fluctuation_potential(std::vector<pq_operator_terms> ops_in);
+
+    /**
+     *
+     * check if there are cluster amplitudes that need to be renamed / expanded as
+     * 't1' = 't1e' or 't1' = 't1e' - 't1d', etc.
+     *
+     * @param ops: a list of pq_operator_terms
+     *
+     */
+    std::pair<bool,std::vector<pq_operator_terms>> process_cluster_amplitudes(std::vector<pq_operator_terms> ops_in);
+
 
     /**
      *

--- a/pdaggerq/pq_string.cc
+++ b/pdaggerq/pq_string.cc
@@ -137,7 +137,7 @@ void pq_string::sort() {
 }
 
 // is string in normal order? both fermion and boson parts
-bool pq_string::is_normal_order() {
+bool pq_string::is_normal_order(bool keep_operators) {
 
     // don't bother bringing to normal order if we're going to skip this string
     if (skip) return true;
@@ -155,7 +155,9 @@ bool pq_string::is_normal_order() {
             bool is_dagger_right = is_dagger_fermi[symbol.size()-1];
             bool is_dagger_left  = is_dagger_fermi[0];
             if ( !is_dagger_right || is_dagger_left ) {
-                skip = true; // added 5/28/21
+                if (!keep_operators) { // added 4/10/26
+                    skip = true; // added 5/28/21
+                }
                 return true;
             }
             if ( !is_dagger_fermi[i] && is_dagger_fermi[i+1] ) {
@@ -165,7 +167,7 @@ bool pq_string::is_normal_order() {
     }
 
     // bosons
-    if ( !is_boson_normal_order() ) {
+    if ( !is_boson_normal_order(keep_operators) ) {
         return false;
     }
 
@@ -173,13 +175,15 @@ bool pq_string::is_normal_order() {
 }
 
 // is boson part of string in normal order?
-bool pq_string::is_boson_normal_order() {
+bool pq_string::is_boson_normal_order(bool keep_operators) {
 
     if ( is_boson_dagger.size() == 1 ) {
         bool is_dagger_right = is_boson_dagger[0];
         bool is_dagger_left  = is_boson_dagger[0];
         if ( !is_dagger_right || is_dagger_left ) {
-            skip = true;
+            if (!keep_operators) { // added 4/10/26
+                skip = true;
+            }
             return true;
         }
     }
@@ -189,12 +193,14 @@ bool pq_string::is_boson_normal_order() {
         bool is_dagger_right = is_boson_dagger[is_boson_dagger.size()-1];
         bool is_dagger_left  = is_boson_dagger[0];
         if ( !is_dagger_right || is_dagger_left ) {
-            skip = true;
+            if (!keep_operators) { // added 4/10/26
+                skip = true;
+            }
             return true;
         }
 
         if ( !is_boson_dagger[i] && is_boson_dagger[i+1] ) {
-            return false;
+            return false; // removed 4/10/26
         }
     }
     return true;
@@ -735,6 +741,61 @@ void pq_string::copy(void * copy_me, bool copy_daggers_and_symbols) {
         // boson daggers
         is_boson_dagger = in->is_boson_dagger;
     }
+}
+
+// append with additional string data
+void pq_string::append(void * add_me){
+
+    auto * in = reinterpret_cast<pq_string * >(add_me);
+
+    // accumulate sign
+    sign *= in->sign;
+
+    // accumulate factor
+    factor *= in->factor;
+
+    // accumulate deltas
+    deltas.insert(deltas.end(), in->deltas.begin(), in->deltas.end());
+
+    // accumulate integrals
+    ints.insert(in->ints.begin(), in->ints.end());
+
+    // accumulate amplitudes
+    amps.insert(in->amps.begin(), in->amps.end());
+
+    // w0
+    if (in->has_w0) {
+        has_w0 = true;
+    }
+
+    // accumulate non-summed spin labels
+    non_summed_spin_labels.insert(in->non_summed_spin_labels.begin(), in->non_summed_spin_labels.end());
+
+    // accumulate permutations
+    permutations.insert(permutations.end(), in->permutations.begin(), in->permutations.end());
+
+    // accumulate paired permutations (2)
+    paired_permutations_2.insert(paired_permutations_2.end(), in->paired_permutations_2.begin(), in->paired_permutations_2.end());
+
+    // accumulate paired permutations (3)
+    paired_permutations_3.insert(paired_permutations_3.end(), in->paired_permutations_3.begin(), in->paired_permutations_3.end());
+
+    // accumulate paired permutations (6)
+    paired_permutations_6.insert(paired_permutations_6.end(), in->paired_permutations_6.begin(), in->paired_permutations_6.end());
+
+    // accumulate fermion operator symbols
+    symbol.insert(symbol.end(), in->symbol.begin(), in->symbol.end());
+
+    // accumulate fermion daggers
+    is_dagger.insert(is_dagger.end(), in->is_dagger.begin(), in->is_dagger.end());
+
+    // accumulate fermion daggers with respect to fermi vacuum
+    if ( vacuum == "FERMI" ) {
+        is_dagger_fermi.insert(is_dagger_fermi.end(), in->is_dagger_fermi.begin(), in->is_dagger_fermi.end());
+    }
+
+    // accumulate boson daggers
+    is_boson_dagger.insert(is_boson_dagger.end(), in->is_boson_dagger.begin(), in->is_boson_dagger.end());
 }
 
 void pq_string::set_spin_everywhere(const std::string &target, const std::string &spin) {

--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -301,14 +301,14 @@ class pq_string
      * is the string in normal order? checks both fermion and boson parts
      *
      */
-    bool is_normal_order();
+    bool is_normal_order(bool keep_operators);
 
     /**
      *
      * is the bosonic part of the string in normal order?
      *
      */
-    bool is_boson_normal_order();
+    bool is_boson_normal_order(bool keep_operators);
 
     /**
      *
@@ -362,6 +362,14 @@ class pq_string
      * @param copy_daggers_and_symbols: copy the dagers and symbols?
      */
     void copy(void * copy_me, bool copy_daggers_and_symbols = true);
+
+    /**
+     *
+     * append string data to an existing string
+     *
+     * @param add_me: pointer to pq_string to be copied
+     */
+    void append(void * add_me);
 
     /**
      *

--- a/pdaggerq/pq_swap_operators.cc
+++ b/pdaggerq/pq_swap_operators.cc
@@ -27,11 +27,12 @@
 
 namespace pdaggerq {
 
-bool swap_operators_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered) {
+bool swap_operators_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered, bool keep_operators) {
 
     if ( in->skip ) return true;
 
-    if ( in->is_normal_order() ) {
+    if ( in->is_normal_order(keep_operators) ) {
+
         // push current ordered operator onto running list
         ordered.push_back(in);
         return true;
@@ -130,7 +131,7 @@ bool swap_operators_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vect
 
     if ( n_new_strings == 1 ) {
 
-        if ( in->is_boson_normal_order() ) {
+        if ( in->is_boson_normal_order(keep_operators) ) {
             if ( !in->skip ) {
                 // copy boson daggers
                 for (size_t i = 0; i < in->is_boson_dagger.size(); i++) {
@@ -181,7 +182,7 @@ bool swap_operators_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vect
 
     }else if ( n_new_strings == 2 ) {
 
-        if ( in->is_boson_normal_order() ) {
+        if ( in->is_boson_normal_order(keep_operators) ) {
             if ( !in->skip ) {
                 // copy boson daggers
                 for (size_t i = 0; i < in->is_boson_dagger.size(); i++) {
@@ -270,11 +271,73 @@ bool swap_operators_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vect
     return false;
 }
 
-bool swap_operators_true_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered) {
+bool swap_operators_fermi_vacuum_no_deltas(std::shared_ptr<pq_string> &in) {
 
     if ( in->skip ) return true;
 
-    if ( in->is_normal_order() ) {
+    // don't call this function here because it will set the "skip" flag
+    //if ( in->is_normal_order() ) {
+    //    return true;
+    //}
+
+    // rearrange operators
+
+    bool am_i_done = true;
+
+    for (int i = 0; i < (int)in->symbol.size()-1; i++) {
+
+        bool swap = ( !in->is_dagger_fermi[i] && in->is_dagger_fermi[i+1] );
+
+        if ( swap ) {
+
+            in->sign = -in->sign;
+
+            std::string tmp_symbol = in->symbol[i];
+            in->symbol[i] = in->symbol[i+1];
+            in->symbol[i+1] = tmp_symbol;
+
+            bool tmp_is_dagger = in->is_dagger[i];
+            in->is_dagger[i] = in->is_dagger[i+1];
+            in->is_dagger[i+1] = tmp_is_dagger;
+
+            bool tmp_is_dagger_fermi = in->is_dagger_fermi[i];
+            in->is_dagger_fermi[i] = in->is_dagger_fermi[i+1];
+            in->is_dagger_fermi[i+1] = tmp_is_dagger_fermi;
+
+            am_i_done = false;
+        }
+    }
+
+    // now, the operator is closer to normal order in the fermion space
+    // we should more toward normal order in the boson space, too
+
+    // don't call this function here because it will set the "skip" flag
+    //if ( in->is_boson_normal_order() ) {
+    //    return false;
+    //}
+
+    for (int i = 0; i < (int)in->is_boson_dagger.size()-1; i++) {
+
+        // swap operators?
+        bool swap = ( !in->is_boson_dagger[i] && in->is_boson_dagger[i+1] );
+
+        if ( swap ) {
+            bool tmp = in->is_boson_dagger[i];
+            in->is_boson_dagger[i] = in->is_boson_dagger[i+1];
+            in->is_boson_dagger[i+1] = tmp;
+            
+            am_i_done = false;
+        }
+    }
+
+    return am_i_done;
+}
+
+bool swap_operators_true_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered, bool keep_operators) {
+
+    if ( in->skip ) return true;
+
+    if ( in->is_normal_order(keep_operators) ) {
 
         // push current ordered operator onto running list
         ordered.push_back(in);
@@ -329,7 +392,7 @@ bool swap_operators_true_vacuum(const std::shared_ptr<pq_string> &in, std::vecto
     // now, s1 and s2 are closer to normal order in the fermion space
     // we should more toward normal order in the boson space, too
 
-    if ( in->is_boson_normal_order() ) {
+    if ( in->is_boson_normal_order(keep_operators) ) {
 
         // copy boson daggers 
         for (size_t i = 0; i < in->is_boson_dagger.size(); i++) {

--- a/pdaggerq/pq_swap_operators.h
+++ b/pdaggerq/pq_swap_operators.h
@@ -38,7 +38,16 @@ namespace pdaggerq {
  * @param in: the input string
  * @param ordered: a list of strings to which the new strings will be added after applying appropriate rules for the swap
  */
-bool swap_operators_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered);
+bool swap_operators_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered, bool keep_operators);
+
+/**
+ *
+ * swap two operators in a string to bring that string toward normal order with respect to the fermi vacuum
+ * without creating a new string with deltas
+ *
+ * @param in: the input string
+ */
+bool swap_operators_fermi_vacuum_no_deltas(std::shared_ptr<pq_string> &in);
 
 /**
  *
@@ -47,7 +56,7 @@ bool swap_operators_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vect
  * @param in: the input string
  * @param ordered: a list of strings to which the new strings will be added after applying appropriate rules for the swap
  */
-bool swap_operators_true_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered);
+bool swap_operators_true_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered, bool keep_operators);
 
 }
 

--- a/pdaggerq/pq_utils.cc
+++ b/pdaggerq/pq_utils.cc
@@ -1612,7 +1612,7 @@ void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &
         // check if this string can be fully contracted ...
         int nc = 0;
         int na = 0;
-        for (size_t i = 0; i < mystring->symbol.size(); i++) {
+        for (size_t i = 0; i < mystring->is_dagger_fermi.size(); i++) {
             if ( mystring->is_dagger_fermi[i] ) nc++;
             else na++;
         }

--- a/pdaggerq/pq_utils.cc
+++ b/pdaggerq/pq_utils.cc
@@ -1605,7 +1605,7 @@ void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &
 
         
     std::vector< std::shared_ptr<pq_string> > new_strings[in.size()];
-    #pragma omp parallel for schedule(dynamic) default(none) shared(in, new_strings) firstprivate(print_level)
+    #pragma omp parallel for schedule(dynamic) default(none) shared(in, new_strings, keep_operators) firstprivate(print_level)
     for (size_t k = 0; k < in.size(); k++) {
         const std::shared_ptr<pq_string>& mystring = in[k];
 

--- a/pdaggerq/pq_utils.cc
+++ b/pdaggerq/pq_utils.cc
@@ -1516,53 +1516,41 @@ void gobble_deltas(std::shared_ptr<pq_string> &in) {
 }
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_true_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations){
+void add_new_string_true_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations){
 
-    if ( in->factor < 0.0 ) {
-        in->sign *= -1;
-        in->factor = fabs(in->factor);
-    }
 
-    for (size_t i = 0; i < in->string.size(); i++) {
-        std::string me = in->string[i];
-        if ( me.find('*') != std::string::npos ) {
-            removeStar(me);
-            in->is_dagger.push_back(true);
-        }else {
-            in->is_dagger.push_back(false);
+    for (auto & my_string: in ) {
+
+        if ( print_level > 0 ) {
+            printf("\n");
+            printf("    ");
+            printf("// starting string:\n");
+            my_string->print();
         }
-        in->symbol.push_back(me);
-    }
 
-    if ( print_level > 0 ) {
-        printf("\n");
-        printf("    ");
-        printf("// starting string:\n");
-        in->print();
-    }
+        // rearrange strings
+        std::vector< std::shared_ptr<pq_string> > tmp;
+        tmp.push_back(my_string);
 
-    // rearrange strings
-    std::vector< std::shared_ptr<pq_string> > tmp;
-    tmp.push_back(in);
+        bool done_rearranging = false;
+        do { 
+            std::vector< std::shared_ptr<pq_string> > list;
+            done_rearranging = true;
+            for (const std::shared_ptr<pq_string> & pq_str : tmp) {
+                bool am_i_done = swap_operators_true_vacuum(pq_str, list);
+                if ( !am_i_done ) done_rearranging = false;
+            }
+            tmp.clear();
+            for (const std::shared_ptr<pq_string> & pq_str : list) {
+                tmp.push_back(pq_str);
+            }
+        }while(!done_rearranging);
 
-    bool done_rearranging = false;
-    do { 
-        std::vector< std::shared_ptr<pq_string> > list;
-        done_rearranging = true;
         for (const std::shared_ptr<pq_string> & pq_str : tmp) {
-            bool am_i_done = swap_operators_true_vacuum(pq_str, list);
-            if ( !am_i_done ) done_rearranging = false;
+            ordered.push_back(pq_str);
         }
         tmp.clear();
-        for (const std::shared_ptr<pq_string> & pq_str : list) {
-            tmp.push_back(pq_str);
-        }
-    }while(!done_rearranging);
-
-    for (const std::shared_ptr<pq_string> & pq_str : tmp) {
-        ordered.push_back(pq_str);
     }
-    tmp.clear();
 
     // alphabetize
     alphabetize(ordered);
@@ -1613,73 +1601,12 @@ bool expand_general_labels(const std::shared_ptr<pq_string> & in, std::vector<st
 }
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, int occ_label_count, int vir_label_count){
+void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, int occ_label_count, int vir_label_count){
         
-    // if normal order is defined with respect to the fermi vacuum, we must
-    // check here if the input string contains any general-index operators
-    // (h, g, f, and v). If it does, then the string must be split to account 
-    // explicitly for sums over occupied and virtual labels
-
-    std::vector< std::shared_ptr<pq_string> > mystrings;
-    mystrings.push_back(in);
-
-    bool done_expanding = false;
-    do {
-        std::vector< std::shared_ptr<pq_string> > list;
-        done_expanding = true;
-        for (const std::shared_ptr<pq_string> & pq_str : mystrings) {
-            bool am_i_done = expand_general_labels(pq_str, list, occ_label_count, vir_label_count);
-            if ( !am_i_done ) done_expanding = false;
-        }
-        if (!done_expanding) {
-            mystrings.clear();
-            for (std::shared_ptr<pq_string> & pq_str : list) {
-                mystrings.push_back(pq_str);
-            }
-            occ_label_count++;
-            vir_label_count++;
-        }
-    }while(!done_expanding);
-
-    // now, we need to convert the list "mystrings[i]->string" into symbols and daggers
-    for (auto & mystring: mystrings ) {
-        for (size_t i = 0; i < mystring->string.size(); i++) {
-            std::string me = mystring->string[i];
-
-            std::string me_nostar = me;
-            if (me_nostar.find('*') != std::string::npos ){
-                removeStar(me_nostar);
-            }
-
-            if ( is_vir(me_nostar) ) {
-                if (me.find('*') != std::string::npos ){
-                    mystring->is_dagger.push_back(true);
-                    mystring->is_dagger_fermi.push_back(true);
-                }else {
-                    mystring->is_dagger.push_back(false);
-                    mystring->is_dagger_fermi.push_back(false);
-                }
-                mystring->symbol.push_back(me_nostar);
-            }else if ( is_occ(me_nostar) ) {
-                if (me.find('*') != std::string::npos ){
-                    mystring->is_dagger.push_back(true);
-                    mystring->is_dagger_fermi.push_back(false);
-                }else {
-                    mystring->is_dagger.push_back(false);
-                    mystring->is_dagger_fermi.push_back(true);
-                }
-                mystring->symbol.push_back(me_nostar);
-            }
-        }
-    }
-
-    // at this point, we've expanded all of the general labels
-    // and are ready to bring the strings to normal order
-
-    std::vector< std::shared_ptr<pq_string> > new_strings[mystrings.size()];
-    #pragma omp parallel for schedule(dynamic) default(none) shared(mystrings, new_strings) firstprivate(print_level)
-    for (size_t k = 0; k < mystrings.size(); k++) {
-        const std::shared_ptr<pq_string>& mystring = mystrings[k];
+    std::vector< std::shared_ptr<pq_string> > new_strings[in.size()];
+    #pragma omp parallel for schedule(dynamic) default(none) shared(in, new_strings) firstprivate(print_level)
+    for (size_t k = 0; k < in.size(); k++) {
+        const std::shared_ptr<pq_string>& mystring = in[k];
 
         // check if this string can be fully contracted ...
         int nc = 0;

--- a/pdaggerq/pq_utils.cc
+++ b/pdaggerq/pq_utils.cc
@@ -1516,7 +1516,7 @@ void gobble_deltas(std::shared_ptr<pq_string> &in) {
 }
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_true_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations){
+void add_new_string_true_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, bool keep_operators){
 
 
     for (auto & my_string: in ) {
@@ -1537,7 +1537,7 @@ void add_new_string_true_vacuum(const std::vector<std::shared_ptr<pq_string>> &i
             std::vector< std::shared_ptr<pq_string> > list;
             done_rearranging = true;
             for (const std::shared_ptr<pq_string> & pq_str : tmp) {
-                bool am_i_done = swap_operators_true_vacuum(pq_str, list);
+                bool am_i_done = swap_operators_true_vacuum(pq_str, list, keep_operators);
                 if ( !am_i_done ) done_rearranging = false;
             }
             tmp.clear();
@@ -1601,7 +1601,8 @@ bool expand_general_labels(const std::shared_ptr<pq_string> & in, std::vector<st
 }
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, int occ_label_count, int vir_label_count){
+void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, bool keep_operators) {
+
         
     std::vector< std::shared_ptr<pq_string> > new_strings[in.size()];
     #pragma omp parallel for schedule(dynamic) default(none) shared(in, new_strings) firstprivate(print_level)
@@ -1647,7 +1648,7 @@ void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &
             std::vector< std::shared_ptr<pq_string> > list;
             done_rearranging = true;
             for (const std::shared_ptr<pq_string> & pq_str : tmp) {
-                bool am_i_done = swap_operators_fermi_vacuum(pq_str, list);
+                bool am_i_done = swap_operators_fermi_vacuum(pq_str, list, keep_operators);
                 if ( !am_i_done ) done_rearranging = false;
             }
             tmp.clear();

--- a/pdaggerq/pq_utils.h
+++ b/pdaggerq/pq_utils.h
@@ -134,10 +134,10 @@ void gobble_deltas(std::shared_ptr<pq_string> &in);
 void use_conventional_labels(std::shared_ptr<pq_string> &in);
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_true_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations);
+void add_new_string_true_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, bool keep_operators);
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, int occ_label_count, int vir_label_count);
+void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, bool keep_operators);
 
 /// concatinate a list of operators (a list of strings) into a single list
 std::vector<std::string> concatinate_operators(const std::vector<std::vector<std::string>> &ops);

--- a/pdaggerq/pq_utils.h
+++ b/pdaggerq/pq_utils.h
@@ -134,10 +134,10 @@ void gobble_deltas(std::shared_ptr<pq_string> &in);
 void use_conventional_labels(std::shared_ptr<pq_string> &in);
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_true_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations);
+void add_new_string_true_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations);
 
 // bring a new string to normal order and add to list of normal ordered strings (fermi vacuum)
-void add_new_string_fermi_vacuum(const std::shared_ptr<pq_string> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, int occ_label_count, int vir_label_count);
+void add_new_string_fermi_vacuum(const std::vector<std::shared_ptr<pq_string>> &in, std::vector<std::shared_ptr<pq_string> > &ordered, int print_level, bool find_paired_permutations, int occ_label_count, int vir_label_count);
 
 /// concatinate a list of operators (a list of strings) into a single list
 std::vector<std::string> concatinate_operators(const std::vector<std::vector<std::string>> &ops);

--- a/test/pq_test.py
+++ b/test/pq_test.py
@@ -80,7 +80,7 @@ def compare_outputs(test_name, script_path):
         raise AssertionError(f"Test {test_name} failed. Check {script_path}/test_outputs/difference/{test_name}_diff.out for details")
 
 # Tests
-ccsd_tests     = ("ccsd", "ccsd_d1", "ccsd_d2", "ccsd_doubles", "ccsd_energy", "ccsd", "ccsd_singles", "ccsd_t",
+ccsd_tests     = ("ccsd", "ccsd_d1", "ccsd_d2", "ccsd_doubles", "ccsd_energy", "ccsd_singles", "ccsd_t",
                   "eom_ccsd_sigma", "ea_eom_ccsd", "eom_ccsd_d1_by_hand", "eom_ccsd_d1", "eom_ccsd_hamiltonian","eom_ccsd", "ip_eom_ccsd", 
                   "lambda_singles", "lambda_doubles", "ccsd_with_spin", "ucc3", "ucc4")
 ci_tests       = ("cid_d1", "cid_d2", "cisd_hamiltonian")


### PR DESCRIPTION
This PR refactors add_operator_product function to remove logic for creating new pq_string objects from that function. It also introduces two new operator types, 'fn' and 'vn', which are fock and fluctuation potential operators that are normal ordered with respect to the fermi vacuum