### PR TITLE
Make everything prints to 12 decimal places because of UCC weird factors

### DIFF
--- a/pdaggerq/algebra.py
+++ b/pdaggerq/algebra.py
@@ -254,7 +254,7 @@ class TensorTerm:
 
         # unprocess (possibly) processed coefficient float
         from fractions import Fraction
-        x = Fraction(coeff).limit_denominator(100)
+        x = Fraction(coeff).limit_denominator(10000)
         coeff = x.numerator/x.denominator
 
         # initialize variables
@@ -293,9 +293,10 @@ class TensorTerm:
         if precision >= repeat_count and last_digit == '0':
             precision -= repeat_count
 
-        # we should always have at least two digits
-        if precision < 2:
-            precision = 2
+        # we should always have at least twelve digits for unitary CC
+        # so, sorry that printing will be awful for other cases
+        if precision < 12:
+            precision = 12
 
         # print coeff with computed precision using nested {}, what could be more pythonic??
         coeff_minprec = f"{coeff: .{precision}f}"

--- a/pdaggerq/pq_string.h
+++ b/pdaggerq/pq_string.h
@@ -78,8 +78,8 @@ template <typename T> int minimum_precision(T factor) {
         precision -= repeat_count;
 
     // we should always have at least two digits
-    if (precision < 2)
-        precision = 2;
+    if (precision < 12)
+        precision = 12;
 
     return precision;
 }


### PR DESCRIPTION
This PR "soft-revert" the functionalities in `pq_strings.h` and `algebra.py` to print the factor in front of each term in a nicer format.

While such functionalities improve the readability of conventional CC/CI codes, they introduce bugs in unitary CC in which the factors can get weird (5/12, 1/144, etc.) such that trimming the decimals too early can introduce non-negligible rounding errors.