### PR TITLE
pq_graph: include <cstdint> for fixed-width integer types (fixes GCC 13+ build)

### DIFF
--- a/pq_graph/include/line.hpp
+++ b/pq_graph/include/line.hpp
@@ -24,6 +24,7 @@
 #ifndef PDAGGERQ_LINE_HPP
 #define PDAGGERQ_LINE_HPP
 
+#include <cstdint>
 #include <utility>
 #include <stdexcept>
 #include <array>

--- a/pq_graph/include/linkage.h
+++ b/pq_graph/include/linkage.h
@@ -24,6 +24,7 @@
 #ifndef PDAGGERQ_linkage_H
 #define PDAGGERQ_linkage_H
 
+#include <cstdint>
 #include <set>
 #include <unordered_set>
 #include <memory>

--- a/pq_graph/include/shape.hpp
+++ b/pq_graph/include/shape.hpp
@@ -24,6 +24,7 @@
 #ifndef PDAGGERQ_SHAPE_HPP
 #define PDAGGERQ_SHAPE_HPP
 
+#include <cstdint>
 #include <sstream>
 #include <clocale>
 #include <stdexcept>

--- a/pq_graph/include/vertex.h
+++ b/pq_graph/include/vertex.h
@@ -23,6 +23,7 @@
 
 #ifndef PDAGGERQ_VERTEX_H
 #define PDAGGERQ_VERTEX_H
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>

--- a/pq_graph/src/linkage.cc
+++ b/pq_graph/src/linkage.cc
@@ -21,6 +21,7 @@
 //  limitations under the License.
 //
 
+#include <cstdint>
 #include <algorithm>
 #include <iostream>
 #include <memory>

--- a/pq_graph/src/term.cc
+++ b/pq_graph/src/term.cc
@@ -21,6 +21,7 @@
 //  limitations under the License.
 //
 
+#include <cstdint>
 #include <algorithm>
 #include <map>
 #include <cmath>

--- a/pq_graph/src/vertex.cc
+++ b/pq_graph/src/vertex.cc
@@ -21,6 +21,7 @@
 //  limitations under the License.
 //
 
+#include <cstdint>
 #include <set>
 #include <utility>
 #include "../include/vertex.h"


### PR DESCRIPTION
## Problem

`pq_graph` fails to compile on modern GCC (13+, tested here on GCC 16.1.1). Several headers and sources use fixed-width integer types such as `uint_fast8_t` / `uint_fast16_t` but rely on `<cstdint>` being pulled in transitively. Recent libstdc++ no longer includes `<cstdint>` indirectly, so the build dies with:

```
pq_graph/include/line.hpp:209:9: error: 'uint_fast8_t' does not name a type
pq_graph/include/shape.hpp:36:5: error: 'uint_fast8_t' does not name a type
```

## Fix

Add the missing `#include <cstdint>` to each `pq_graph` file that uses a fixed-width integer type directly without already including it. The include is placed with the other includes at the top of each file. No logic, formatting, or other includes are changed — 7 files, 7 insertions.

| File |
|------|
| `pq_graph/include/line.hpp` |
| `pq_graph/include/shape.hpp` |
| `pq_graph/include/vertex.h` |
| `pq_graph/include/linkage.h` |
| `pq_graph/src/vertex.cc` |
| `pq_graph/src/term.cc` |
| `pq_graph/src/linkage.cc` |

## Verification

A clean `pip install .` build from scratch on GCC 16.1.1 compiles successfully, and `import pdaggerq` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)