### PR TITLE
pq_graph: fix out-of-bounds write for external lines in build_connections

### DIFF
--- a/pq_graph/src/linkage.cc
+++ b/pq_graph/src/linkage.cc
@@ -169,8 +169,10 @@ namespace pdaggerq {
             bool right_external =  left_idx < 0;
 
             // keep track of external indicies
-            left_ext_idx[  left_idx] =  left_external;
-            right_ext_idx[right_idx] = right_external;
+            // (a -1 index means the line is absent on that side, so skip it to avoid an
+            //  out-of-bounds write at index -1)
+            if ( left_idx >= 0)  left_ext_idx[ left_idx] =  left_external;
+            if (right_idx >= 0) right_ext_idx[right_idx] = right_external;
 
             // update flop scaling
             flop_scale_ += line;


### PR DESCRIPTION
## Problem

`pq_graph` crashes (segfault/abort, no Python traceback) when optimizing coupled-cluster equations involving quadruple excitations. CCSD and CCSDT optimize fine; anything with an 8-line amplitude/projection (quadruples) dies. The crash is independent of `opt_level` (0, 2, 6) and `low_memory`, and happens even with a single quadruples equation added alone — so it is not optimizer OOM or cross-equation fusion.

## Root cause

`Linkage::build_connections()` records which lines of the left/right vertices are external using two stack arrays indexed by each line's position on its side:

```cpp
bool left_ext_idx[left_size], right_ext_idx[right_size];
...
const auto &[left_idx, right_idx] = line_connec;   // int_fast8_t; -1 == "absent on that side"
...
left_ext_idx[  left_idx] =  left_external;
right_ext_idx[right_idx] = right_external;
```

The index pair uses `-1` to mean "this line is not present on that side" (i.e. the line is external). For **every external line**, one of `left_idx`/`right_idx` is therefore `-1`, so these statements write to `left_ext_idx[-1]` / `right_ext_idx[-1]` — a one-byte out-of-bounds write just before the array.

It is harmless for the small stack frames of CCSD/CCSDT but corrupts the larger frames produced by quadruples, causing the crash. The corruption occurs while computing term scaling in `PQGraph::add()` → `Term::compute_scaling()`, which is why it reproduces at every `opt_level`.

UBSan pinpoints it deterministically:

```
pq_graph/src/linkage.cc:172:36: runtime error: index -1 out of bounds for type 'bool [*]'
  #0 Linkage::build_connections()           pq_graph/src/linkage.cc:172
  #1 Linkage::Linkage(...)                   pq_graph/src/linkage.cc:44
  ...
  #11 Term::compute_scaling(...)             pq_graph/src/term.cc:471
  #13 Term::Term(...)                        pq_graph/src/term.cc:128
  #14 PQGraph::add(...)                      pq_graph/src/pq_graph.cc:451
```

## Fix

Guard both writes with the same `idx >= 0` check that `Linkage::internal_lines()` already uses when iterating `connec_map_`, so the `-1` sentinel is skipped instead of indexing out of bounds. When a line is absent on a side there is no corresponding entry to mark, so skipping is correct.

## Verification

- **Before:** UBSan reports the `index -1` out-of-bounds write on a quadruples equation (deterministic).
- **After:** the same ASan+UBSan run is completely clean and the equation optimizes (e.g. a quadruples Fock residual → 204 generated lines).
- **No regression:** CCSDT codegen output is byte-for-byte identical before and after the fix.

Built and tested with GCC 16.1.1 / Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)