### PR TITLE
core: bound peak memory of similarity-transform generation (enables quadruples)

### DIFF
--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -879,9 +879,76 @@ void pq_helper::process_operator_products(std::vector<pq_operator_terms> ops) {
         ops = new_ops;
     }while(!done_processing);
 
+    // While generating terms, periodically fold the running list down with the
+    // confluent (combine-only) part of simplify(). The brute-force normal
+    // ordering of high-rank similarity transforms (e.g. the two-electron
+    // operator with quadruple excitations) produces tens of millions of fully
+    // contracted raw terms that only collapse to a small set after cancellation;
+    // accumulating them all before simplify() exhausts memory (std::bad_alloc).
+    // Consolidating incrementally bounds peak memory to roughly one operator
+    // product's contribution plus the (small) combined result, without changing
+    // the final equations -- permutation-operator detection is left for the
+    // final simplify() so the output is identical to consolidating once at the
+    // end. This is only safe/meaningful for standard fermi-vacuum CC.
+    const bool can_consolidate = ( vacuum == "FERMI" && !use_rdms && !is_unitary_cc );
+    size_t consolidate_threshold = 100000;
+    if ( const char * env = getenv("PQ_CONSOLIDATE_THRESHOLD") ) {
+        consolidate_threshold = strtoull(env, nullptr, 10);
+    }
+
     for (auto op : ops){
         add_operator_product(op.factor, op.operators);
+        if ( can_consolidate && ordered.size() > consolidate_threshold ) {
+            consolidate_running_terms();
+        }
     }
+}
+
+void pq_helper::consolidate_running_terms() {
+
+    // apply delta functions and canonicalize labels so that equivalent terms
+    // acquire matching signatures (mirrors the per-string portion of simplify()).
+    for (std::shared_ptr<pq_string> & pq_str : ordered) {
+        if ( pq_str->skip ) continue;
+        gobble_deltas(pq_str);
+        reclassify_integrals(pq_str);
+        use_conventional_labels(pq_str);
+    }
+
+    // keep only fully contracted, non-skipped strings (mirrors the FERMI prune
+    // in cleanup(); terms that are not fully contracted never survive simplify()).
+    std::vector<std::shared_ptr<pq_string> > pruned;
+    pruned.reserve(ordered.size());
+    for (std::shared_ptr<pq_string> & pq_str : ordered) {
+        if ( pq_str->skip ) continue;
+        if ( !pq_str->symbol.empty() ) continue;
+        if ( !pq_str->is_boson_dagger.empty() ) continue;
+        pq_str->sort(); // sets the key used by consolidate_permutations_plus_swaps
+        pruned.push_back(pq_str);
+    }
+    ordered = pruned;
+
+    // combine terms that are equal up to swaps of (up to two) summed labels.
+    // this is the same sequence cleanup() uses, but without the subsequent
+    // permutation-operator formation, which is deferred to the final simplify().
+    static const std::vector<std::string> occ_labels { "i", "j", "k", "l", "m", "n", "I", "J", "K", "L", "M", "N" };
+    static const std::vector<std::string> vir_labels { "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F" };
+
+    consolidate_permutations_plus_swaps(ordered, {});
+    consolidate_permutations_plus_swaps(ordered, {occ_labels});
+    consolidate_permutations_plus_swaps(ordered, {vir_labels});
+    consolidate_permutations_plus_swaps(ordered, {occ_labels, occ_labels});
+    consolidate_permutations_plus_swaps(ordered, {vir_labels, vir_labels});
+    consolidate_permutations_plus_swaps(ordered, {occ_labels, vir_labels});
+
+    // drop the terms that were merged away so their memory is released
+    std::vector<std::shared_ptr<pq_string> > kept;
+    kept.reserve(ordered.size());
+    for (std::shared_ptr<pq_string> & pq_str : ordered) {
+        if ( pq_str->skip ) continue;
+        kept.push_back(pq_str);
+    }
+    ordered = kept;
 }
 
 // wrapper for python calling add_operator_product directly

--- a/pdaggerq/pq_helper.h
+++ b/pdaggerq/pq_helper.h
@@ -283,6 +283,22 @@ class pq_helper {
     void process_operator_products(std::vector<pq_operator_terms> ops);
 
     /**
+     * Incrementally combine the running list of terms in `ordered` while it is
+     * being generated. This applies only the confluent, combine-only portion of
+     * simplify()/cleanup() (per-string delta/label canonicalization followed by
+     * consolidate_permutations_plus_swaps), so it is mathematically identical to
+     * consolidating once at the end -- permutation-operator formation is deferred
+     * to the final simplify(). Its purpose is to bound peak memory for expansions
+     * that would otherwise generate tens of millions of raw terms (e.g. the
+     * similarity transform of the two-electron operator with quadruple
+     * excitations) before any cancellation occurs.
+     *
+     * Only used for normal order relative to the fermi vacuum in standard
+     * (non-RDM, non-unitary) coupled-cluster expansions.
+     */
+    void consolidate_running_terms();
+
+    /**
      *
      * check if there are fluctuation potential operators that need to
      * be split into multiple terms


### PR DESCRIPTION
## Problem

Building any coupled-cluster equation whose cluster operator includes `t4` (e.g. the CCSDTQ residual) crashes with `std::bad_alloc`/abort during the **second** `add_st_operator` (the two-electron operator `v`), with no Python traceback. CCSDT (`t1..t3`) is fine.

```python
pq = pdaggerq.pq_helper("fermi")
pq.set_left_operators([["e4(i,j,k,l,d,c,b,a)"]])
pq.add_st_operator(1.0, ["f"], ["t1","t2","t3","t4"])   # ok
pq.add_st_operator(1.0, ["v"], ["t1","t2","t3","t4"])   # <-- dies here
```

This is **not** a fixed-width integer overflow. A gdb backtrace shows a clean `std::bad_alloc → terminate → abort` inside the OpenMP Wick region; UBSan is clean; and the raw term count scales smoothly with excitation rank (no narrow-type cliff).

## Cause

`add_st_operator` expands the similarity transform into operator products and brute-force normal-orders each one, accumulating **every fully contracted raw term** in the running list `ordered` before any cancellation happens (cancellation is deferred to `simplify()`). Those raw terms collapse enormously on simplify — e.g. an `e4` projection of `[v, t1]` produces **504,576** raw terms that cancel to **zero** — but for `t4` the running list reaches tens of millions of terms and exhausts memory first.

Measured: 100% of the raw terms pushed to `ordered` are already fully contracted, so the explosion is pure accumulation of terms that only combine across the whole set.

## Fix

Fold the running list down **incrementally** during generation. Once `ordered` grows past a threshold, apply only the **confluent, combine-only** part of `simplify()`:

- per-string delta application and label canonicalization (`gobble_deltas`, `reclassify_integrals`, `use_conventional_labels`), then
- `consolidate_permutations_plus_swaps` over the same label-set sequence `cleanup()` uses.

Permutation-operator (`P`/`PP`) formation is **deferred to the final `simplify()`**, so the incremental pass only merges equivalent terms and cancels zeros — making it mathematically identical to consolidating once at the end. It just keeps the running list small, bounding peak memory to roughly one operator product's contribution plus the (small) combined result.

Only active for standard fermi-vacuum CC (not RDM / unitary CC). The threshold can be overridden with the `PQ_CONSOLIDATE_THRESHOLD` environment variable (set very large to restore the previous accumulate-everything behaviour).

## Verification

- **Identical equations:** core `pq.strings()` output is byte-for-byte identical with and without incremental consolidation for energy / CCSD / CCSDT (including with `find_paired_permutations`), and is deterministic across thread counts.
- **Quadruples now generate:** the full CCSDTQ residual builds — **731 terms, ~7.4 GB peak RSS** (previously **>56 GB → crash**) — and the result is **identical for consolidation thresholds of 40k / 100k / 300k** (a confluence check). It then optimizes through `pq_graph` end to end (7044 lines of generated code).

Built and tested with GCC 16.1.1 / Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)