### PR TITLE
pq_graph: make optimization deterministic across runs

### DIFF
--- a/pq_graph/src/consolidate.cc
+++ b/pq_graph/src/consolidate.cc
@@ -312,7 +312,12 @@ void PQGraph::substitute(bool format_sigma, bool only_scalars) {
          * Iterate over all test scalings, remove incompatible ones, and sort them
          */
 
-        std::multimap<scaling_map, MutableLinkagePtr> sorted_test_data;
+        // candidate substitutions, ordered by scaling. ties (linkages that yield the
+        // same scaling) are broken by a canonical key so that the substitution order
+        // -- and therefore the generated intermediates and final equations -- does not
+        // depend on the order in which the parallel search happened to populate the
+        // candidate set (which varies with thread scheduling).
+        std::vector<std::tuple<scaling_map, std::string, MutableLinkagePtr>> sorted_test_data;
         for (auto &[test_flop_map, test_linkage]: test_data) {
 
             // skip empty linkages
@@ -343,11 +348,20 @@ void PQGraph::substitute(bool format_sigma, bool only_scalars) {
 
 
             if (keep) {
-                sorted_test_data.insert(make_pair(test_flop_map, test_linkage));
+                sorted_test_data.emplace_back(test_flop_map, test_linkage->tot_str(true), test_linkage);
             } else {
                 ignore_linkages.insert(test_linkage); // add linkage to ignore linkages
             }
         }
+
+        // sort by scaling (best first), breaking ties on the canonical linkage string
+        std::sort(sorted_test_data.begin(), sorted_test_data.end(),
+                  [](const std::tuple<scaling_map, std::string, MutableLinkagePtr> &a,
+                     const std::tuple<scaling_map, std::string, MutableLinkagePtr> &b) {
+                      if (std::get<0>(a) < std::get<0>(b)) return true;
+                      if (std::get<0>(b) < std::get<0>(a)) return false;
+                      return std::get<1>(a) < std::get<1>(b);
+                  });
         substitute_timer.stop(); // stop timer for substitution
 
         makeSub = !sorted_test_data.empty();
@@ -369,7 +383,7 @@ void PQGraph::substitute(bool format_sigma, bool only_scalars) {
             update_timer.start();
 
             size_t batch_count = 0;
-            for (const auto &[found_flop, found_linkage]: sorted_test_data) {
+            for (const auto &[found_flop, found_key, found_linkage]: sorted_test_data) {
 
                 substitute_timer.start();
 


### PR DESCRIPTION
Fixes #103.

## Problem

`pq_graph.optimize()` produced **different output on identical inputs from run to run** for larger problems whenever `OMP_NUM_THREADS > 1`. For example, generating EOM-CCSD or spin-blocked CCSDT code twice with the same settings yields different equations (e.g. `d(j,m)` vs `d(i,m)`, different dummy-index choices and intermediate factorizations). With a single thread the output is fully deterministic. This makes generated code non-reproducible and prevents pinning/diffing a certified schedule.

## Cause

In `PQGraph::substitute()`, candidate intermediates are ordered by scaling in a `std::multimap<scaling_map, LinkagePtr>` and substituted in that order. Candidates with **equal scaling** (very common) are kept in multimap **insertion order**, which is the iteration order of the candidate set populated by the parallel search in `make_all_links()` — i.e. it depends on OpenMP thread scheduling. The tie-broken choice then cascades into different substitutions, intermediates, and final emitted code.

(The candidate *set* itself is deterministic — only the order in which equally-good candidates are applied was not.)

## Fix

Replace the `multimap` with an explicitly sorted vector: order candidates by scaling first (best first, as before), breaking ties on a canonical, fully-expanded linkage string (`tot_str(true)`). This makes the substitution order — and therefore the generated equations — independent of thread scheduling. Only the tie-break among equally-good candidates changes, so the result is an equally-valid factorization. (The string key is precomputed once per candidate rather than recomputed inside the comparator.)

## Verification

- **Reproducible:** all spin-orbital and spin-blocked reference methods (`ccsd`, `cisd`, `lambda_ccsd`, `ccsd_with_spin`, `ccsdt`, `cc3`, `eom_ccsd`, `ccsdt_with_spin`) now produce byte-identical code across repeated multithreaded runs. Previously `eom_ccsd` and `ccsdt_with_spin` differed run to run. Reproducing the issue's acceptance test directly: CCSDT optimized 8× at `OMP_NUM_THREADS=8` now gives **1 distinct schedule** (was 11/12).
- **Correct:** the optimized code was checked against the unoptimized (`opt_level` 0) equations by evaluating both on random antisymmetrized integrals/amplitudes with numpy — CCSD residuals match exactly, CCSDT residuals match to ~1e-13 (floating-point roundoff).

Built and tested with GCC 16.1.1 / Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)