### PR TITLE
pq_graph: don't fuse intermediates at truncated depth in the batched path

### DIFF
--- a/pq_graph/src/consolidate.cc
+++ b/pq_graph/src/consolidate.cc
@@ -490,10 +490,22 @@ void PQGraph::substitute(bool format_sigma, bool only_scalars) {
             num_merged = merge_terms();
             total_num_merged += num_merged;
 
-            size_t num_fused = merge_intermediates();
-            if (num_fused > 0) {
-                total_num_merged += num_fused;
-                cout << "Fused " << num_fused << " terms." << endl;
+            // Only fuse intermediates once candidate generation has reached full
+            // depth. Under the batched path, current_depth grows incrementally
+            // (1, 2, ...); fusing while intermediates are still generated at a
+            // truncated depth can merge two intermediates whose surrounding
+            // (truncated) terms compare equal at low depth but diverge once
+            // expanded to full depth -- producing a wrong linear combination.
+            // The non-batched path always runs at full depth (so this is a no-op
+            // there); any fusions deferred here are still applied by the
+            // full-depth merge_intermediates() call after the substitution loop.
+            bool at_full_depth = !batched_ || current_depth >= org_max_depth;
+            if (at_full_depth) {
+                size_t num_fused = merge_intermediates();
+                if (num_fused > 0) {
+                    total_num_merged += num_fused;
+                    cout << "Fused " << num_fused << " terms." << endl;
+                }
             }
 
             prune();


### PR DESCRIPTION
Fixes #104.

## Problem

`pq_graph.optimize()` run with `{"batched": true}` can silently **mis-factorize**: evaluated on identical inputs the resulting schedule disagrees with the unoptimized (`opt_level=0`) equations by amounts far above numerical tolerance (O(1e1)). On the same input, `opt_level=0`, `5`, and `6` are all correct — only the batched path is wrong.

## Cause

With `batched_`, `PQGraph::substitute()` generates candidates starting at `Term::max_depth_ = 1` and grows the depth incrementally, calling `merge_intermediates()` (intermediate fusion) **inside** the substitution loop at each step. Fusing while intermediates are still generated at a **truncated depth** can merge two intermediates whose surrounding (truncated) terms compare equal at low depth but **diverge once expanded to full depth** — e.g. fusing a `g(l,m,j,d)`-derived and a `g(l,m,d,e)`-derived intermediate and then contracting the sum with one summand's permutation set. The emitted equations are then algebraically wrong.

## Fix

Guard the in-loop `merge_intermediates()` so it only runs once candidate generation has reached full depth (`current_depth >= org_max_depth`). The non-batched path always runs at full depth, so this is a **no-op** there. Fusions deferred from truncated depth are still applied by the existing full-depth `merge_intermediates()` call **after** the substitution loop, so no fusion is lost — only deferred to a depth where the equivalence test is valid.

## Verification

Against the reporter's minimal 6-term reproducer (a 1-minimal CC3 triples residual over a bare-Coulomb integral, `permute_eri=False`), evaluating each schedule against the `opt_level=0` transcription on random tensors at `OMP_NUM_THREADS=8`:

| path | before | after |
|---|---|---|
| `opt5` / `opt6` | 0/12 (Δ 7e-15) | 0/12 (Δ 7e-15) |
| `opt6 batched` | **12/12 (Δ 2.2e+01)** | **0/12 (Δ 1.4e-14)** |
| 1-minimality sweep (drop any 1 of 6 terms) | mixed | **6/6 pass** |

`opt5`/`opt6` and all non-batched paths are unchanged.

## Note

This is the truncated-depth (single-equation) batched defect. A *separate* batched mis-fusion that fires at full depth across multiple equations is tracked in #105 and is **not** addressed here. Independently, `set_options` forces `batch_size_ = 1` whenever `batched` is set (processed after `batch_size`), so real batching is currently unreachable from the API — a usability issue worth a follow-up but orthogonal to this correctness fix.

Built and tested with GCC 16.1.1 / Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)