### PR TITLE
Reset spin/range blocking flags in the pq_helper constructor

### DIFF
--- a/pdaggerq/blocking_leak_test.py
+++ b/pdaggerq/blocking_leak_test.py
@@ -1,0 +1,57 @@
+"""Regression test for the process-global spin/range blocking-state leak.
+
+``block_by_spin`` / ``block_by_range`` set static flags on ``pq_string``
+(``is_spin_blocked`` / ``is_range_blocked``) that were previously only reset by
+``clear()``. A freshly constructed ``pq_helper`` must start unblocked -- otherwise a
+prior blocking call on a *different* helper leaks in through the shared statics and
+``strings()`` returns this helper's (empty) ``ordered_blocked`` instead of its real
+equations, surfacing as "Empty terms for Equation". The ``pq_helper`` constructor now
+resets both flags. Run: python -m pdaggerq.blocking_leak_test
+"""
+import pdaggerq
+
+
+def _energy():
+    """A small closed-shell equation with only summed labels (works for both
+    spin and range blocking)."""
+    pq = pdaggerq.pq_helper("fermi")
+    pq.set_left_operators([["1"]])
+    pq.add_st_operator(1.0, ["v"], ["t2"])
+    pq.simplify()
+    return pq
+
+
+def test_spin_block_does_not_leak():
+    a = _energy()
+    a.block_by_spin({"i": "a", "j": "a", "a": "a", "b": "a"})
+    assert len(a.strings()) > 0
+    fresh = _energy()                                  # never blocked
+    assert len(fresh.strings()) > 0, "is_spin_blocked leaked from a prior helper"
+    print("test_spin_block_does_not_leak OK")
+
+
+def test_range_block_does_not_leak():
+    a = _energy()
+    a.block_by_range({"i": ["all"], "j": ["all"], "a": ["all"], "b": ["all"]})
+    assert len(a.strings()) > 0
+    fresh = _energy()
+    assert len(fresh.strings()) > 0, "is_range_blocked leaked from a prior helper"
+    print("test_range_block_does_not_leak OK")
+
+
+def test_fresh_after_block_matches_never_blocked():
+    # the fresh (post-block) equation must equal the never-blocked one exactly
+    ref = sorted(" ".join(t) for t in _energy().strings())
+    poison = _energy()
+    poison.block_by_spin({"i": "a", "j": "a", "a": "a", "b": "a"})
+    poison.strings()
+    after = sorted(" ".join(t) for t in _energy().strings())
+    assert after == ref, (len(after), len(ref))
+    print("test_fresh_after_block_matches_never_blocked OK")
+
+
+if __name__ == "__main__":
+    test_spin_block_does_not_leak()
+    test_range_block_does_not_leak()
+    test_fresh_after_block_matches_never_blocked()
+    print("\nall blocking-leak tests passed")

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -187,6 +187,13 @@ pq_helper::pq_helper(const std::string &vacuum_type)
     /// left operators type (EE, IP, EA)
     left_operators_type = "EE";
 
+    // is_spin_blocked / is_range_blocked are process-global (static on pq_string) but
+    // only reset by clear(); a fresh helper must start unblocked so that a prior
+    // block_by_spin/block_by_range on a *different* helper cannot leak in and make
+    // strings() read the (empty) blocked equations of this one.
+    pq_string::is_spin_blocked = false;
+    pq_string::is_range_blocked = false;
+
 }
 
 pq_helper::pq_helper(const pq_helper &other) {


### PR DESCRIPTION
## Problem

`pq_string::is_spin_blocked` and `is_range_blocked` are process-global (`static inline`) flags — set by `block_by_spin` / `block_by_range`, but only reset by `pq_helper::clear()`. So once any equation is spin/range-blocked, the flag stays set for the rest of the process, and a later **freshly constructed** `pq_helper` — never blocked, hence with an empty `ordered_blocked` — has `strings()` read that empty blocked list instead of its real equations. It surfaces as `ValueError: Empty terms for Equation:`.

Practical symptom: a script (or test suite) that spin-blocks one equation and then builds another, unblocked one **in the same process** gets empty terms for the second — even though each works fine in isolation / a fresh interpreter.

## Fix

Reset both flags in the `pq_helper` constructor, so a fresh helper always starts unblocked and cannot inherit a prior (possibly different) helper's blocking state.

## Test

Adds `pdaggerq/blocking_leak_test.py`, a self-contained reproducer: block one helper by spin and by range, then confirm a fresh helper still returns its real equations (and that the post-block equation matches the never-blocked one exactly). Verified on a Release build that it **fails without** this change (`AssertionError: is_spin_blocked leaked from a prior helper`) and **passes with** it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
