### PR TITLE
pq_graph: output-neutral optimizer hot-spot fixes (1.5x optimize, 9x emit on CCSDT triples)

### DIFF
--- a/pq_graph/src/term.cc
+++ b/pq_graph/src/term.cc
@@ -451,6 +451,12 @@ namespace pdaggerq {
             return "";
 
         string comment;
+        string assign_str = is_assignment_ ? "  = " : " += "; // also used by the flop/mem lines below
+
+        // the operator string is expensive (tot_str fully expands every linked operand);
+        // skip building it entirely when only the flop/mem lines are wanted -- it was
+        // previously assembled and then discarded at the only_flop check below.
+        if (!only_flop) {
         for (const auto &vertex: rhs_) {
             if (vertex->is_linked())
                 comment += as_link(vertex)->tot_str(true);
@@ -511,8 +517,6 @@ namespace pdaggerq {
         double coeff = coefficient_;
         bool is_negative = coeff < 0;
 
-        string assign_str = is_assignment_ ? "  = " : " += ";
-
         int precision = minimum_precision(coefficient_);
         string coeff_str = to_string_with_precision(fabs(coefficient_), precision);
         if (is_negative) coeff_str.insert(coeff_str.begin(), '-');
@@ -524,9 +528,7 @@ namespace pdaggerq {
         } else {
             comment = "// " + lhs_->name() + assign_str + original_pq_;
         }
-
-        if (only_flop) // clear comment if only flop is requested
-            comment.clear();
+        } // end if (!only_flop): the comment built above is unused when only_flop is set
 
         // remove all quotes from comment
         comment.erase(std::remove(comment.begin(), comment.end(), '\"'), comment.end());


### PR DESCRIPTION
Six contained, output-neutral performance fixes for the `pq_graph` optimizer hot spots, guided by `perf` profiling of a CCSDT-class optimization (95% of wall time in the substitution loop; ~40% of cycles in allocator traffic; the candidate indexing quadratic and mutex-serialized).

1. **Candidate-set snapshot** (`consolidate.cc`): the parallel scoring loop indexed `test_linkages[i]`, and `linkage_set::operator[](size_t)` is `*next(begin(), i)` over an `unordered_set` under a mutex — O(n²) in the candidate count and fully lock-serialized. One O(n) copy into a `std::vector` before the loop makes candidate access lock-free and O(1).
2. **Cached structural hash** (`linkage.h`, `linkage.cc`, `linkage_set.hpp`): `LinkageHash` re-hashed `base_name_` — the recursive structural string, whose length grows with the subtree — on every container operation. The hash is now computed lazily once and cached on the `Linkage` (`base_hash_`), invalidated in `set_properties()` (the only writer of a Linkage's `base_name_`) and copied in `copy_link()` alongside the string. `LinkageEqual` gains a hash short-circuit (different hash ⇒ different `base_name_` ⇒ not equal, since `operator==` ends by comparing `base_name_` via `Vertex::equivalent`). The hash **values** are unchanged (`std::hash` of the same string), so container iteration order — and therefore output — is unchanged. Deliberately built only from the immutable structural name: `id_`/`reused_` stay out of hash/equality (they are mutated in place on stored linkages).
3. **No lazy-cache copying in `copy_link`** (`linkage.cc`): `shallow()`/copy construction duplicated the memoization vectors (`all_vert_`, `link_vector_`, and `permutations_`, which can hold up to depth! full subtrees), atomically bumping every contained `shared_ptr` refcount. The caches regenerate on demand (`link_vector()`/`permutations()` rebuild when empty), so copies now start empty.
4. **Dead work removed from the destructor scan** (`graph_printing.cc`): the reverse scan for temp last-use built a full `term.str()` and per-operand `op->str()` rendering on every iteration and discarded them (plus an empty `if` with `bool test = true;`) — inside an O(n²) loop.
5. **`make_comments(only_flop)` short-circuit** (`term.cc`): the full operator/permutation/coefficient comment string was assembled and then cleared when only the flop/mem lines were requested; it is now skipped up front.
6. **Flat small-buffer line matching in `build_connections`** (`linkage.cc`): the per-Linkage `unordered_map<const Line*, array<int8,2>>` (built for every Linkage ever constructed; line counts are tensor ranks, i.e. tiny) is replaced by a stack-buffer scan with `Line::operator==` — identical semantics including duplicate collapse (`connec_map_` is sorted afterwards as before).

### Measured (6 OMP threads, Release; `opt_level 5`)

| case | before | after | speedup |
|---|---|---|---|
| CCSD doubles residual, optimize | 0.16 s | 0.17 s | — (noise) |
| CCSDT doubles residual, optimize | 0.20 s | 0.19 s | — |
| **CCSDT triples residual, optimize** | **79.2 s** | **51.7 s** | **1.53×** |
| **CCSDT triples residual, `to_strings`** | **0.99 s** | **0.11 s** | **9×** |

### Output equivalence

Emission is **byte-identical** to unpatched `master` (same md5 of `to_strings("python")` for the CCSD and CCSDT doubles residuals, both builds from the same worktree). `test/pq_test.py` (37 tests) passes.

The remaining large cost identified by the profile — incremental candidate re-testing across substitution iterations (dirty-term tracking) — is more invasive and left for a follow-up.

Independent of #116 (no overlapping hunks); the two combine cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
