### PR TITLE
ensures "factor" is non-negative at the end of add_operator_product

### DIFF
--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -1042,6 +1042,12 @@ void pq_helper::add_operator_product(double factor, std::vector<std::string>  in
 
                         newguy->factor *= factor;
 
+                        // ensure factor is non-negative
+                        if (newguy->factor < 0.0){
+                            newguy->factor = fabs(newguy->factor);
+                            newguy->sign *= -1;
+                        } 
+
                         new_pq_strings.push_back(newguy);
 
                     }


### PR DESCRIPTION
This PR fixes a mostly innocuous bug introduced while refactoring the add_operator_product function. the pq_string attribute "factor" should be non-negative, but this was no longer guaranteed. 