### PR TITLE
pq_graph: make the optimizer thread-count-invariant (deterministic multithreaded codegen)

### DIFF
--- a/pq_graph/include/linkage_set.hpp
+++ b/pq_graph/include/linkage_set.hpp
@@ -85,6 +85,24 @@ namespace pdaggerq {
             do_sort_();
         }
 
+        // Insert keeping the CANONICAL representative among structural duplicates: dedup is
+        // label-invariant (LinkageEqual), so two structurally-equal candidates that differ
+        // only in their generic labels collide, and a plain unordered_set keeps whichever
+        // was inserted FIRST -- which, under the parallel candidate generation, depends on
+        // thread scheduling and makes the surviving labeling (and thus the generated code)
+        // nondeterministic. Keeping the lexicographically-smallest tot_str makes the survivor
+        // order-independent. Returns true if the set changed. Caller must hold mtx_.
+        bool insert_canonical_(const LinkagePtr &lk) {
+            auto result = linkages_.insert(lk);
+            if (result.second) return true;
+            if (lk->tot_str(true) < (*result.first)->tot_str(true)) {
+                linkages_.erase(result.first);
+                linkages_.insert(lk);
+                return true;
+            }
+            return false;
+        }
+
     public:
         typedef linkage_vector::const_iterator const_iterator;
 
@@ -127,23 +145,30 @@ namespace pdaggerq {
 
         auto insert(const VertexPtr &linkage) {
             std::lock_guard<std::mutex> lock(mtx_);
-            auto result = linkages_.insert(as_link(linkage));
-            if (result.second) dirty_.store(true, std::memory_order_release);
+            auto lk = as_link(linkage);
+            // capture result BEFORE any canonical swap so the returned iterator stays valid
+            auto result = linkages_.insert(lk);
+            if (result.second) {
+                dirty_.store(true, std::memory_order_release);
+            } else if (lk->tot_str(true) < (*result.first)->tot_str(true)) {
+                linkages_.erase(result.first);
+                result.first = linkages_.insert(lk).first;
+                dirty_.store(true, std::memory_order_release);
+            }
             return result;
         }
 
         void insert(const typename linkage_vector::const_iterator &begin, const typename linkage_vector::const_iterator &end) {
             std::lock_guard<std::mutex> lock(mtx_);
-            size_t old_size = linkages_.size();
-            linkages_.insert(begin, end);
-            if (linkages_.size() != old_size) dirty_.store(true, std::memory_order_release);
+            bool changed = false;
+            for (auto it = begin; it != end; ++it) changed |= insert_canonical_(*it);
+            if (changed) dirty_.store(true, std::memory_order_release);
         }
         void insert(const typename vertex_vector::const_iterator &begin, const typename vertex_vector::const_iterator &end) {
             std::lock_guard<std::mutex> lock(mtx_);
-            size_t old_size = linkages_.size();
-            for (auto it = begin; it != end; ++it)
-                linkages_.insert(as_link(*it));
-            if (linkages_.size() != old_size) dirty_.store(true, std::memory_order_release);
+            bool changed = false;
+            for (auto it = begin; it != end; ++it) changed |= insert_canonical_(as_link(*it));
+            if (changed) dirty_.store(true, std::memory_order_release);
         }
 
         size_t count(const LinkagePtr &linkage) const {
@@ -238,10 +263,10 @@ namespace pdaggerq {
         }
 
         linkage_set &operator+=(const linkage_set &other) {
-            std::lock_guard<std::mutex> lock(mtx_);
-            size_t old_size = linkages_.size();
-            linkages_.insert(other.linkages_.begin(), other.linkages_.end());
-            if (linkages_.size() != old_size) dirty_.store(true, std::memory_order_release);
+            std::scoped_lock lock(mtx_, other.mtx_);
+            bool changed = false;
+            for (const auto &lk : other.linkages_) changed |= insert_canonical_(lk);
+            if (changed) dirty_.store(true, std::memory_order_release);
             return *this;
         }
 

--- a/pq_graph/src/linkage_ops.cc
+++ b/pq_graph/src/linkage_ops.cc
@@ -178,20 +178,20 @@ namespace pdaggerq {
 
         // copy the result vector to the link_vector if the size is less than cache size
         bool store_vector = cache_elements_ && cache_depth_ >= depth;
-        if (store_vector) {
-            // Lock the mutex for this scope
+        // all reads/writes of the cache members are under the lock: the previous
+        // `else if (... && !all_vert_.empty())` checks read the member OUTSIDE the lock,
+        // racing with a concurrent forget()/assignment on another thread.
+        {
             std::lock_guard<std::mutex> lock(mtx_);
-            if (fully_expand)
-                 all_vert_ = result;
-            else link_vector_ = result;
-        } else if (fully_expand && !all_vert_.empty()) {
-            // if not storing the vector, clear the all_vert_ vector
-            std::lock_guard<std::mutex> lock(mtx_);
-            all_vert_.clear();
-        } else if (!fully_expand && !link_vector_.empty()) {
-            // if not storing the vector, clear the link_vector_ vector
-            std::lock_guard<std::mutex> lock(mtx_);
-            link_vector_.clear();
+            if (store_vector) {
+                if (fully_expand)
+                     all_vert_ = result;
+                else link_vector_ = result;
+            } else {
+                // not storing (depth beyond cache_depth_): drop any stale cache
+                if (fully_expand) all_vert_.clear();
+                else link_vector_.clear();
+            }
         }
 
         // return the result vector
@@ -534,15 +534,11 @@ namespace pdaggerq {
                 result.push_back(as_link(right_perm + left_perm));
             }
 
-            // copy the result vector to the permutations_ vector only if caching is enabled and the size is less than cache size
-            if (cache_permutations) {
-                // Lock the mutex for the scope
+            // store or drop the cache -- all under the lock (see the general case below).
+            {
                 std::lock_guard<std::mutex> lock(mtx_);
-                permutations_ = result;
-            } else if (!permutations_.empty()) {
-                // if not storing permutations, clear the permutations_ vector
-                std::lock_guard<std::mutex> lock(mtx_);
-                permutations_.clear();
+                if (cache_permutations) permutations_ = result;
+                else permutations_.clear();
             }
 
             return result;
@@ -559,15 +555,12 @@ namespace pdaggerq {
             result.push_back(link(link_vec, idxs));
         }
 
-        // copy the result vector to the permutations_ vector only if low memory mode is off
-        if (cache_permutations) {
-            // Lock the mutex for the scope
+        // store or drop the cache -- all under the lock (the old `else if
+        // (!permutations_.empty())` read the member outside the lock, racing with forget()).
+        {
             std::lock_guard<std::mutex> lock(mtx_);
-            permutations_ = result;
-        } else if (!permutations_.empty()) {
-            // if not storing permutations, clear the permutations_ vector
-            std::lock_guard<std::mutex> lock(mtx_);
-            permutations_.clear();
+            if (cache_permutations) permutations_ = result;
+            else permutations_.clear();
         }
         return result;
 

--- a/pq_graph/src/pq_graph.cc
+++ b/pq_graph/src/pq_graph.cc
@@ -814,6 +814,22 @@ namespace pdaggerq {
         print_guard guard;
         if (print_level_ < 1) guard.lock();
 
+        // Pin the printer backend for the duration of optimization. Candidate ordering
+        // keys are built from str()/tot_str(), which branch on Vertex::printer_ -- a
+        // process-wide pointer that to_strings() overwrites (set_printer). Without pinning,
+        // the optimization result depends on which output format was last emitted in the
+        // process, so the FIRST optimize() in a process (printer_ at its default) differs
+        // from every later one (printer_ left at the last-emitted backend). Force a fixed
+        // backend here and restore it after. (Declared after the print_guard so
+        // set_printer's status line is suppressed, and destroyed before it so the restore
+        // is suppressed too.)
+        const CodePrinter *saved_printer = Vertex::printer_;
+        Vertex::set_printer("c++");
+        struct PrinterRestore {
+            const CodePrinter *p;
+            ~PrinterRestore() { Vertex::printer_ = p; }
+        } printer_restore{saved_printer};
+
         if (flop_map_init_.empty() || mem_map_init_.empty()) {
             flop_map_init_ = flop_map_;
             mem_map_init_ = mem_map_;


### PR DESCRIPTION
The pq_graph optimizer is the dominant cost of code generation, but its emitted code depended on the thread count, so anything freezing the generated code had to pin it to a single thread. Three fixes make the output **byte-identical at any thread count**, so codegen can run multithreaded and stay reproducible.

### 1. Canonical candidate representative (`linkage_set`)
Dedup is label-invariant (`LinkageEqual` compares structure, not labels), so two structurally-equal candidate intermediates that differ only in their generic labels collide, and a plain `unordered_set` kept whichever was inserted **first** — under the parallel candidate search that's thread-order-dependent, so the surviving labeling (and thus the emitted code) varied run to run. `insert` now keeps the lexicographically-smallest `tot_str` representative. (Instrumentation confirmed the candidate set is *structurally* identical every run; only the kept labels varied.)

### 2. Printer pin during `optimize()`
Candidate ordering keys are built from `str()`/`tot_str()`, which branch on `Vertex::printer_` — a process-wide pointer that `to_strings()` overwrites. Without pinning, the optimization result depends on which output format was emitted last, so the **first** `optimize()` in a process differs from every later one — a determinism bug independent of threading. The backend is pinned for the duration of optimization and restored after.

### 3. Complete the `Linkage` lazy-cache locking
`link_vector()`/`permutations()` read the cache members' `.empty()` **outside** the mutex before locking to clear them — a double-checked-lock race with `forget()`. Those reads are now under the lock.

### Verification
- **Correctness — `tests/numerical_test.py`:** all 7 non-spin tests pass (codegen + execution of the generated code). The `*_codegen.py` scripts run at `nthreads=-1`, so this exercises the multithreaded path.
- **Determinism/thread-invariance:** `ccsd_codegen.py` now emits byte-identical code regardless of thread count — `OMP_NUM_THREADS=1` and `=6` both give md5 `c6941fe0d717221b469985c880cb7ac4`, reproducible run-to-run (before this PR it varied).
- The fusion pass keeps its parallelism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)