### PR TITLE
pq_graph: don't rename intermediates when stripping the trial index

### DIFF
--- a/pq_graph/include/vertex.h
+++ b/pq_graph/include/vertex.h
@@ -392,6 +392,20 @@ namespace pdaggerq {
         }
 
         /**
+         * check if vertex has no lines that will actually be printed
+         * @return true if every line is omitted from the emitted index string
+         * @note trial (sigma) indices are not materialized as a tensor dimension unless
+         *       use_trial_index is set, so a vertex whose only lines are sigma lines is
+         *       printed as a scalar factor even though its rank is nonzero.
+         */
+        bool is_printed_scalar() const {
+            if (use_trial_index) return lines_.empty();
+            for (const Line &line : lines_)
+                if (!line.sig_) return false;
+            return true;
+        }
+
+        /**
          * check if vertex is a constant
          */
         bool is_constant() const;

--- a/pq_graph/src/printers/blas_printer.cc
+++ b/pq_graph/src/printers/blas_printer.cc
@@ -88,16 +88,18 @@ string BLASPrinter::format_contraction(
 
 string BLASPrinter::format_lines(const line_vector& lines) const {
     if (lines.empty()) return "";
-    string out = "(";
-    for (size_t i = 0; i < lines.size(); ++i) {
-        if (i > 0) out += ",";
-        if (!lines[i].label_.empty())
-            out += lines[i].label_;
+    string out;
+    for (const Line &line : lines) {
+        // trial (sigma) indices are not a materialized tensor dimension unless requested
+        if (line.sig_ && !Vertex::use_trial_index) continue;
+        if (!out.empty()) out += ",";
+        if (!line.label_.empty())
+            out += line.label_;
         else
-            out += (lines[i].type() == 'v' ? 'a' : lines[i].type());
+            out += (line.type() == 'v' ? 'a' : line.type());
     }
-    out += ")";
-    return out;
+    if (out.empty()) return "";
+    return "(" + out + ")";
 }
 
 string BLASPrinter::format_declarations(const set<string>& names) const {

--- a/pq_graph/src/printers/einsum_printer.cc
+++ b/pq_graph/src/printers/einsum_printer.cc
@@ -68,12 +68,13 @@ string EinsumPrinter::format_contraction(
         if (op->is_addition() && !op->is_temp())
             s = "(" + s + ")";
 
-        if (op->is_scalar()) {
+        if (op->is_printed_scalar()) {
             output += s + " * ";
         } else {
             tensor_strs.push_back(std::move(s));
             string labels, types;
             for (const auto& line : op->lines()) {
+                if (line.sig_ && !Vertex::use_trial_index) continue;
                 labels += line.label_[0];
                 types  += line.type();
             }

--- a/pq_graph/src/printers/loop_printer.cc
+++ b/pq_graph/src/printers/loop_printer.cc
@@ -86,16 +86,18 @@ string LoopPrinter::format_contraction(
 
 string LoopPrinter::format_lines(const line_vector& lines) const {
     if (lines.empty()) return "";
-    string out = "(";
-    for (size_t i = 0; i < lines.size(); ++i) {
-        if (i > 0) out += ",";
-        if (!lines[i].label_.empty())
-            out += lines[i].label_;
+    string out;
+    for (const Line &line : lines) {
+        // trial (sigma) indices are not a materialized tensor dimension unless requested
+        if (line.sig_ && !Vertex::use_trial_index) continue;
+        if (!out.empty()) out += ",";
+        if (!line.label_.empty())
+            out += line.label_;
         else
-            out += (lines[i].type() == 'v' ? 'a' : lines[i].type());
+            out += (line.type() == 'v' ? 'a' : line.type());
     }
-    out += ")";
-    return out;
+    if (out.empty()) return "";
+    return "(" + out + ")";
 }
 
 string LoopPrinter::format_declarations(const set<string>& names) const {

--- a/pq_graph/src/printers/tamm_printer.cc
+++ b/pq_graph/src/printers/tamm_printer.cc
@@ -54,7 +54,7 @@ string TammPrinter::format_contraction(
         if (op->is_addition() && !op->is_temp())
             s = "(" + s + ")";
 
-        if (op->is_scalar()) {
+        if (op->is_printed_scalar()) {
             output += s + " * ";
         } else {
             tensor_strs.push_back(std::move(s));

--- a/pq_graph/src/printers/tiledarray_printer.cc
+++ b/pq_graph/src/printers/tiledarray_printer.cc
@@ -55,7 +55,7 @@ string TiledArrayPrinter::format_contraction(
         if (op->is_addition() && !op->is_temp())
             s = "(" + s + ")";
 
-        if (op->is_scalar()) {
+        if (op->is_printed_scalar()) {
             output += s + " * ";
         } else {
             tensor_strs.push_back(std::move(s));

--- a/pq_graph/src/vertex_printing.cc
+++ b/pq_graph/src/vertex_printing.cc
@@ -146,6 +146,17 @@ namespace pdaggerq {
         if (!Vertex::use_trial_index) {
             vertex_vector link_vector_no_trial;
             for (const auto &op: link_vector) {
+                // Never strip an intermediate. An intermediate is printed by NAME, and that
+                // name is derived from its full line set (dimstring), so dropping the sigma
+                // line here silently RENAMES it: the definition site keeps the sigma type
+                // (tmps_["0003_Loovo"]) while every use site loses it (tmps_["0003_oovo"]),
+                // and the emitted code then reads an intermediate that was never assigned.
+                // The printers omit sigma lines themselves when building index strings, so
+                // intermediates need no stripping here.
+                if (op->is_temp()) {
+                    link_vector_no_trial.push_back(op);
+                    continue;
+                }
                 MutableVertexPtr new_op = op->clone();
                 line_vector new_lines;
                 for (const auto &line: new_op->lines())


### PR DESCRIPTION
## The bug

`Linkage::tot_str()` clones every operand and drops its sigma (trial) lines when
`use_trial_index` is false (`pq_graph/src/vertex_printing.cc:146`). An intermediate is
printed **by name**, and that name is derived from its full line set via `dimstring()`, so
the strip silently **renames** it. The definition site and the deallocation keep the sigma
type, every use site loses it:

```python
    tmps_["0001_Loovo"]  = 1.000 * einsum('jkcb,cl->jkbl',l2,t1)      # defined
    ...
    tmps_["0002_Lvo"]  = 1.000 * einsum('dbjk,jkbl->dl',t2,tmps_["0001_oovo"])   # KeyError
    ...
    del tmps_["0001_Loovo"]
```

Executing the emitted code raises `KeyError` before producing a number.

Only equations with sigma lines are affected — i.e. anything built through
`set_left_operators()`: Lambda residuals, EOM/sigma builds. It is not printer-specific;
`to_strings("c++")` splits the same names.

## Reproducer

The plain CCSD Lambda singles residual, no extensions:

```python
import re, pdaggerq

pq = pdaggerq.pq_helper("fermi")
pq.set_left_operators([["1"], ["l1"], ["l2"]])
for h in ["f", "v"]:
    pq.add_st_operator( 1.0, [h, "e1(i,a)"], ["t1", "t2"])
    pq.add_st_operator(-1.0, ["e1(i,a)", h], ["t1", "t2"])
pq.simplify()

g = pdaggerq.pq_graph({"opt_level": 6, "print_level": 0})
g.add(pq, "R")
g.optimize()
py = "\n".join(g.to_strings("python"))

# every intermediate id must map to exactly ONE full name
byid = {}
for n in set(re.findall(r'tmps_\["([^"]+)"\]', py)):
    byid.setdefault(n.split("_")[0], set()).add(n)
print({k: sorted(v) for k, v in byid.items() if len(v) > 1})
```

On `db6767b` this prints 12 intermediates carrying two different names:

```
{'0001': ['0001_Loovo', '0001_oovo'], '0003': ['0003_Lvoov', '0003_voov'],
 '0004': ['0004_Lvvoo', '0004_vvoo'], '0009': ['0009_Lvooo', '0009_vooo'], ...}
```

and a use-before-definition scan of the same output finds **99** statements reading a
`tmps_` entry that is never assigned. After this PR both are **0**.

## The fix

Never strip an intermediate in `tot_str()`. The printers already omit sigma lines
themselves when they build index strings (`EinsumPrinter` `format_lines` /
`format_term` / `format_addition`, `TiledArrayPrinter::format_lines`,
`TammPrinter::format_lines`), so intermediates need no stripping at all.

The two places that *did* rely on the pre-strip are updated to skip sigma lines directly:

- the operand-label loop in `EinsumPrinter::format_contraction`;
- `BLASPrinter::format_lines` and `LoopPrinter::format_lines` — which also fixes a
  pre-existing asymmetry there, since their LHS printed the sigma index while the RHS
  did not.

New `Vertex::is_printed_scalar()` preserves the scalar-factor classification for a vertex
whose only lines are sigma lines, which the strip used to produce by reducing it to rank 0.

Equations without sigma lines are unchanged by construction: with no sigma line the
stripped clone was line-identical to the original, the new `continue` never fires, and
`is_printed_scalar()` reduces to `is_scalar()`.

## Verification

- `tests/numerical_test.py` (`-k "not with_spin"`, per your note on #122 that this is the
  test for pq_graph changes): **7 passed**, before and after.
- Reproducer above: 12 split names / 99 undefined uses → **0 / 0**, in both
  `to_strings("python")` and `to_strings("c++")`.
- The emitted CCSD Lambda python now **executes end to end** under numpy at `no=4, nv=6`
  — singles 185 statements, residual shape `(v,o)`; doubles 2782 statements, residual
  shape `(v,v,o,o)`. Before the fix both raised `KeyError` on the first renamed
  intermediate.

Found downstream, where the emitted Lambda python was being used as an independent
reference for a CC implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e7TKYhaJLwpedBBzfRqcK
