### PR TITLE
tests: un-break the algebra/parser tests and make generated_code writes CWD-independent

### DIFF
--- a/pdaggerq/algebra_test.py
+++ b/pdaggerq/algebra_test.py
@@ -16,7 +16,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from pdaggerq.algebra import (BaseTerm, Index, TensorTerm, T1amps, T2amps,
+from pdaggerq.algebra import (BaseTerm, Index, TensorTerm, Rank1Amps, Rank2Amps,
                               TwoBody, OneBody)
 import numpy as np
 
@@ -40,12 +40,12 @@ def test_index():
 
 def test_baseterm():
     term = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='h', spin='')
+                    name='h', spin='', boson='', active='')
     assert term.indices[0] == Index('i', 'occ')
     assert term.indices[1] == Index('j', 'occ')
 
     term2 = BaseTerm(indices=(Index('k', 'occ'), Index('l', 'occ')),
-                    name='t1', spin='')
+                    name='t1', spin='', boson='', active='')
     tensort = term2 * term
     assert isinstance(tensort, TensorTerm)
 
@@ -58,29 +58,29 @@ def test_baseterm():
 
 def test_tensorterm():
     hij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='h', spin='')
+                    name='h', spin='', boson='', active='')
     t1ij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='t', spin='')
+                    name='t', spin='', boson='', active='')
     tensor_term = TensorTerm(base_terms=(hij, t1ij))
     assert tensor_term.coefficient == 1.0
 
-    assert tensor_term.__repr__() == " 1.0000 h(i,j)*t(i,j)"
+    assert tensor_term.__repr__() == " 1.000000000000 h(i,j)*t(i,j)"
 
     hij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='h', spin='_aa')
+                    name='h', spin='_aa', boson='', active='')
     t1ij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='t', spin='_aa')
+                    name='t', spin='_aa', boson='', active='')
     tensor_term = TensorTerm(base_terms=(hij, t1ij))
     assert tensor_term.coefficient == 1.0
 
-    assert tensor_term.__repr__() == " 1.0000 h_aa(i,j)*t_aa(i,j)"
+    assert tensor_term.__repr__() == " 1.000000000000 h_aa(i,j)*t_aa(i,j)"
 
 
 def test_tensor_multiply():
     hij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='h', spin='')
+                    name='h', spin='', boson='', active='')
     t1ij = BaseTerm(indices=(Index('i', 'occ'), Index('j', 'occ')),
-                    name='t', spin='')
+                    name='t', spin='', boson='', active='')
     tensor_term = TensorTerm(base_terms=(hij, t1ij))
     test_tensor_term = tensor_term * 4
     assert isinstance(test_tensor_term, TensorTerm)
@@ -91,7 +91,7 @@ def test_tensor_multiply():
     assert np.isclose(test_tensor_term.coefficient, 4)
 
     t1kl = BaseTerm(indices=(Index('k', 'occ'), Index('l', 'virt')),
-                    name='t', spin='')
+                    name='t', spin='', boson='', active='')
     test_tensor_term = tensor_term * t1kl
     assert test_tensor_term.base_terms[2] == t1kl
 
@@ -102,9 +102,9 @@ def test_tensor_multiply():
 def test_preset_tensor_terms():
     i, j, a, b = Index('i', 'occ'), Index('j', 'occ'), Index('a', 'virt'), \
                  Index('b', 'virt'),
-    test_term = T1amps(indices=(i, a))
+    test_term = Rank1Amps(indices=(i, a))
     assert test_term.name == 't1'
-    test_term = T2amps(indices=(i, j, b, a))
+    test_term = Rank2Amps(indices=(i, j, b, a))
     assert test_term.name == 't2'
     test_term = TwoBody(indices=(i, j, b, a))
     assert test_term.name == 'g'

--- a/pdaggerq/numerical/codegen/autogen.py
+++ b/pdaggerq/numerical/codegen/autogen.py
@@ -1,5 +1,21 @@
 import pdaggerq 
+import os
 import re
+
+#: Directory the ``write_function=True`` generators write their modules to. A
+#: relative path resolves against the current working directory, which is why
+#: writing straight to "generated_code/..." only worked when the caller happened
+#: to be run from tests/. Callers that import what they generate should set this
+#: to the absolute directory they put on ``sys.path``.
+generated_code_dir = "generated_code"
+
+
+def write_generated_function(function_name, code):
+    """Write one generated module, creating the output directory if needed."""
+    os.makedirs(generated_code_dir, exist_ok=True)
+    with open(os.path.join(generated_code_dir, f"{function_name}.py"), "w") as file:
+        file.write(code)
+
 
 # Map fermionic order -> list of spin channels
 SPIN_MAP = {
@@ -485,8 +501,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -609,8 +624,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -719,8 +733,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -836,8 +849,7 @@ f"""
     
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -944,8 +956,7 @@ def uccsd_energy(order,
     
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -1054,8 +1065,7 @@ f"""
     
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -1214,8 +1224,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -1315,8 +1324,7 @@ def lambda_cc_pseudoenergy(energy_name,
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -1664,8 +1672,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -1996,8 +2003,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     pq.clear()
 
@@ -2299,8 +2305,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     return generated_code_string
 
@@ -2403,8 +2408,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     return generated_code_string
 
@@ -2580,8 +2584,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     return generated_code_string
 
@@ -2939,8 +2942,7 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     return generated_code_string
 
@@ -3256,7 +3258,6 @@ f"""
 
     # write function 
     if write_function:
-        with open(f"generated_code/{function_name}.py", "w") as file:
-            file.write(generated_code_string)
+        write_generated_function(function_name, generated_code_string)
 
     return generated_code_string

--- a/pdaggerq/parser_test.py
+++ b/pdaggerq/parser_test.py
@@ -17,7 +17,7 @@
 #   limitations under the License.
 
 from pdaggerq.parser import contracted_strings_to_tensor_terms
-from pdaggerq.algebra import BaseTerm, TensorTerm, Index, TwoBody, T2amps, T1amps
+from pdaggerq.algebra import BaseTerm, TensorTerm, Index, TwoBody, Rank2Amps, Rank1Amps
 
 
 def test_parse_strings_to_tensor():
@@ -30,11 +30,11 @@ def test_parse_strings_to_tensor():
    energy_tensor_terms = contracted_strings_to_tensor_terms(energy_strings)
    i, j, a, b = Index('i', 'occ'), Index('j', 'occ'), Index('a', 'virt'), Index(
       'b', 'virt')
-   h_ii = BaseTerm(indices=(i, i), name='f', spin='')
-   f_ia = BaseTerm(indices=(i, a), name='f', spin='')
-   t1 = T1amps(indices=(a, i))
+   h_ii = BaseTerm(indices=(i, i), name='f', spin='', boson='', active='')
+   f_ia = BaseTerm(indices=(i, a), name='f', spin='', boson='', active='')
+   t1 = Rank1Amps(indices=(a, i))
    g_ijab = TwoBody(indices=(i, j, a, b), name='g')
-   t2_abij = T2amps(indices=(a, b, j, i), name='t2')
+   t2_abij = Rank2Amps(indices=(a, b, j, i), name='t2')
 
    eterm1 = TensorTerm(base_terms=(h_ii,))
    eterm2 = TensorTerm(base_terms=(f_ia, t1,), coefficient=1)

--- a/tests/pq_numerical_test.py
+++ b/tests/pq_numerical_test.py
@@ -68,6 +68,11 @@ def test_ccsd_codegen_disk():
     script_path = os.path.dirname(os.path.realpath(__file__))
     gen_dir = os.path.join(script_path, "generated_code")
     os.makedirs(gen_dir, exist_ok=True)
+
+    # point the generators at the very directory we are about to import from,
+    # so the test does not depend on being invoked from tests/
+    from pdaggerq.numerical.codegen import autogen
+    autogen.generated_code_dir = gen_dir
     
     # Add the generation directory to sys.path so Python can import from it
     if gen_dir not in sys.path:


### PR DESCRIPTION
Three test-harness defects found while reconciling #112 with the `canonicalize_labels` line. None needed a code change to reproduce — they were simply never run.

### `algebra_test.py` and `parser_test.py` have not run since January 2025

`2d58741` renamed `T1amps`/`T2amps` to `Rank1Amps`/`Rank2Amps`. The tests still import the old names, so the import raises `ImportError` and pytest reports a **collection error** rather than a failure — easy to scroll past, and the six tests in those two modules have not executed since.

Renamed, and brought the rest of both modules up to date with the code they test:

* `BaseTerm` also requires the `boson` and `active` sectors now (no defaults).
* `TensorTerm`’s repr carries twelve decimals — deliberate, per `_minimum_precision`: *"we should always have at least twelve digits for unitary CC"*.

### `test_ccsd_codegen_disk` wrote its modules to the wrong directory

The test builds an absolute `generated_code/` next to itself and puts it on `sys.path`, but `autogen` wrote to a **relative** `"generated_code/{name}.py"`. The modules therefore landed in the caller’s working directory, and the `sys.path` entry pointed at something that was never written. Run from anywhere except `tests/` the test dies with

```
FileNotFoundError: [Errno 2] No such file or directory: 'generated_code/cc_energy.py'
```

All fifteen write sites now go through `write_generated_function()`, which honours a module-level `generated_code_dir` and creates it; the test points that at the directory it imports from. `tests/generated_code/` is already in `.gitignore`, so the intended location is unchanged.

### Verification

45 tests pass (`tests/pq_test.py`, `pdaggerq/`, `pq_graph/tests/`), including the six that were previously never collected, and `test_ccsd_codegen_disk` now passes from the repository root as well as from `tests/`.

### One judgment call

`BaseTerm.__init__` requires `boson`/`spin`/`active` with no defaults, while *every* subclass defaults them to `''` and the docstring says "leave as an empty string". Giving `BaseTerm` the same defaults would be the tidier fix. I updated the tests instead rather than change the API in a test PR — happy to switch if you would prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e7TKYhaJLwpedBBzfRqcK