### PR TITLE
pq_graph: emit an intermediate's declaration before every use of it (opt_level 6)

### DIFF
--- a/pq_graph/src/graph_printing.cc
+++ b/pq_graph/src/graph_printing.cc
@@ -206,9 +206,30 @@ namespace pdaggerq {
         // keep track of tmp ids that have been found
         set<long> declare_ids;
 
+        // A declaration is placed immediately before the first term that uses it, but a
+        // term only becomes visible here once it is in all_terms -- and other temp
+        // declarations are use sites too. So a declaration has to wait until every
+        // not-yet-placed declaration that reads it has been placed, or it lands after
+        // one of its own uses and the generated code reads an intermediate that does not
+        // exist yet. Walking ids downwards covers this only while a temp depends purely
+        // on lower ids; fusion (opt_level 6) merges intermediates and can leave a
+        // lower-id temp reading a higher-id one.
+        auto used_by_unplaced = [&](long temp_id) {
+            for (const auto &other : copy.equations_["temp"]) {
+                if (!other.lhs()->is_temp()) continue;
+                long other_id = as_link(other.lhs())->id();
+                if (other_id == temp_id) continue;
+                if (declare_ids.find(other_id) != declare_ids.end()) continue; // already placed
+                const idset rhs_ids = other.term_linkage()->get_ids("temp");   // reads only
+                if (rhs_ids.find(temp_id) != rhs_ids.end()) return true;
+            }
+            return false;
+        };
+
         // add declaration for each tmp
         bool found_any;
         size_t attempts = 0;
+        bool relax_deps = false; // drop the rule for one pass if it ever blocks everything
 
         do {
             found_any = false;
@@ -223,6 +244,9 @@ namespace pdaggerq {
 
                 // check if tmp is already declared
                 if (declare_ids.find(temp_id) != declare_ids.end()) continue;
+
+                // defer until everything that reads this tmp has been placed
+                if (!relax_deps && used_by_unplaced(temp_id)) continue;
 
                 bool found = false;
                 for (auto i = 0ul; i < all_terms.size(); ++i) {
@@ -274,7 +298,16 @@ namespace pdaggerq {
 
                 }
             }
-        } while (found_any && ++attempts < copy.equations_["temp"].size());
+
+            if (!found_any && !relax_deps) {
+                // every remaining declaration was deferred; a dependency cycle should be
+                // impossible, but fall back to the old unordered placement rather than
+                // dropping the declarations entirely.
+                relax_deps = true;
+                found_any  = true;
+            } else relax_deps = false;
+
+        } while (found_any && ++attempts < 2 * copy.equations_["temp"].size() + 2);
 
 
         // add a term to destroy the tmp after its last use


### PR DESCRIPTION
This is the `opt_level = 6` failure in the new numerical tests. `tests/pq_graph_numerical_test.py` runs at opt 6 by default, and `eom_ccsd` and `eom_ccsd_quick` both die in the generated python with

```
KeyError: '0021_ov'
```

### What the generator emits

```python
tmps_["0020_vo"]  = -2.000 * einsum('caik,kc->ai', t2, tmps_["0021_ov"])   # line 1368
...
tmps_["0021_ov"]  =  1.000 * einsum('ijab,ai->jb', eri["oovv"], t1)        # line 1389
```

The definition of `0021_ov` lands 21 lines *after* its use.

### Why

A declaration is placed immediately before the first term that uses it, and that search walks temp ids downwards. That relies on a temp only ever reading temps with **smaller** ids: a reader then has a higher id, is placed first, and so is already in the stream by the time the temp it reads is placed.

Fusion breaks the invariant. `merge_intermediates()` combines a temp with others and can leave a lower-id temp reading a higher-id one. The placement search then never sees the use at all, because the only term reading it is another declaration that has not been placed yet — declarations only become visible once they are in the stream.

`Equation::sort_tmp_type` cannot repair it afterwards. For this pair it reports the two terms *equivalent* (each has max id 21), so the stable sort preserves whatever order fusion left — which is the order in which the merged declaration was inserted at the front of the equation in `LinkMerger::merge()`.

### The fix

Defer a declaration until every not-yet-placed declaration that reads it has been placed, so placement order follows the actual dependencies instead of the id ordering. A one-pass fallback keeps a (supposedly impossible) dependency cycle degrading to the old behaviour rather than dropping declarations.

Below opt 6 nothing changes: without fusion a temp is only read by higher-id temps, which are placed first, so the new rule never defers.

### Verification

* `tests/pq_graph_numerical_test.py`: **7 passed / 2 failed → 9 passed**
* `eom_ccsd` codegen still emits the same 37 intermediates, now with **none** used before defined (opt 5 emits 55, and was already correct)
* `tests/pq_test.py` + the `pdaggerq` suite: 39 passed, unchanged
* `tests/pq_numerical_test.py` forced to `opt_level: 6`: 19 passed

Two notes from the same sweep, in case they are what you were seeing:

* `tests/pq_numerical_test.py::test_ccsd_codegen_disk` fails at **any** opt level unless pytest is invoked from `tests/` — a relative-path bug, fixed separately in #131.
* I could not reproduce any other opt-6 failure; with the above, everything I ran at opt 6 passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e7TKYhaJLwpedBBzfRqcK