### PR TITLE
pq_graph: parenthesise a fused scalar addition in the emitted contraction

### DIFF
--- a/pq_graph/src/printers/einsum_printer.cc
+++ b/pq_graph/src/printers/einsum_printer.cc
@@ -65,7 +65,13 @@ string EinsumPrinter::format_contraction(
     for (const auto& op : operators) {
         if (op->empty()) continue;
         string s = op->str();
-        if (op->is_expandable(false, true))
+        // An addition has to be parenthesised: it binds looser than the product this
+        // operand sits in. is_expandable(false, true) is the general test, but it also
+        // insists the operand is not a SCALAR, so a FUSED SCALAR ADDITION -- several
+        // scalars merged into one by opt_level 6 -- answered false and printed as
+        // "a + b + c * tensor" instead of "(a + b + c) * tensor", silently adding the
+        // scalars to the result instead of scaling by their sum.
+        if (op->is_expandable(false, true) || (!op->is_temp() && op->is_addition()))
             s = "(" + s + ")";
 
         if (op->is_printed_scalar()) {

--- a/pq_graph/src/printers/tamm_printer.cc
+++ b/pq_graph/src/printers/tamm_printer.cc
@@ -51,7 +51,10 @@ string TammPrinter::format_contraction(
     for (const auto& op : operators) {
         if (op->empty()) continue;
         string s = op->str();
-        if (op->is_expandable(false, true))
+        // parenthesise an addition -- it binds looser than the product this operand
+        // sits in. is_expandable(false, true) answers false for a SCALAR addition
+        // (see EinsumPrinter::format_contraction), which opt_level 6 fusion produces.
+        if (op->is_expandable(false, true) || (!op->is_temp() && op->is_addition()))
             s = "(" + s + ")";
 
         if (op->is_printed_scalar()) {

--- a/pq_graph/src/printers/tiledarray_printer.cc
+++ b/pq_graph/src/printers/tiledarray_printer.cc
@@ -52,7 +52,10 @@ string TiledArrayPrinter::format_contraction(
     for (const auto& op : operators) {
         if (op->empty()) continue;
         string s = op->str();
-        if (op->is_expandable(false, true))
+        // parenthesise an addition -- it binds looser than the product this operand
+        // sits in. is_expandable(false, true) answers false for a SCALAR addition
+        // (see EinsumPrinter::format_contraction), which opt_level 6 fusion produces.
+        if (op->is_expandable(false, true) || (!op->is_temp() && op->is_addition()))
             s = "(" + s + ")";
 
         if (op->is_printed_scalar()) {


### PR DESCRIPTION
This is the `test_qed_ccsd_21_codegen` / `test_qed_ccsd_22_codegen` failure at `opt_level = 6` from #132.

### Symptom

At opt 6 fusion merges several scalars into one sum, and the python printer emitted that sum unparenthesised:

```python
r1_bb -= einsum('jJ,jJ->',Id["aa_oo"],dp["aa_oo"]) + scalars_["0003"] + scalars_["0002"] + scalars_["0001"] * t1_1p["bb"]
```

Python reads that as `s4 + s3 + s2 + (s1 * t1_1p)`, so three of the four scalars are **added** to the residual instead of scaling `t1_1p`. The solver still converges — to a wrong energy. QED-CCSD-21 gave `-75.015549927139` against the reference `-75.015650410563`.

### Cause

`format_contraction()` does guard against this — it parenthesises an operand when `is_expandable(false, true)`. But that predicate ends in

```cpp
( !is_scalar() || expand_scalar )
```

so with `expand_scalar = false` it answers **false for anything scalar**, and a fused scalar addition is precisely that. The missing case is added: an addition needs parentheses whether or not it is a scalar.

The fusion itself is correct — those four scalars do belong in one sum. This is a latent printer bug that opt 6 merely reaches, since below 6 the scalars are emitted as separate statements. The **TiledArray and TAMM printers carry the same guard with the same omission**, and `a + b * c` binds identically there, so all three are fixed.

### How it was isolated

With the `PQ_FUSION_MAX_MERGES` budget: of the 84 merge groups in QED-CCSD-21, the failure first appears at the fourth, which merges

```
dot(Id["aa_oo"], dp["aa_oo"])   dot(Id["bb_oo"], dp["bb_oo"])
dot(dp["aa_ov"], t1["aa"])      dot(dp["bb_ov"], t1["bb"])
```

all multiplying `t1_1p` in `r1`. Bisecting the opt level gave opt4 pass / opt5 pass / opt6 fail, pointing at fusion.

### Verification

Run at opt 6 set in `autogen.configure_graph` — thanks for pointing out that this, not the dict in `pq_numerical_test.py`, is what the numerical solvers read:

* `test_qed_ccsd_21_codegen`, `test_qed_ccsd_22_codegen`: fail → pass
* `tests/pq_graph_numerical_test.py` (opt 6 by default): 9 passed
* `tests/pq_test.py` + the `pdaggerq` suite: unchanged

### One thing I could not finish, and it is worth flagging separately

A full `tests/pq_numerical_test.py` run at opt 6 does not complete here. `test_uccsd_4_codegen` consumed **over two hours of CPU and 2.8 GB** without producing any generated code, and `test_eomccsd_codegen` is similar. Both die inside optimisation, not printing — `perf` shows the time in the linkage machinery (mutexes and allocation), and the process never emits code at all, so this is unrelated to the change here. With those deselected the rest of the suite passes.

If you intend `opt_level = 6` to be usable as the default for the numerical tests, that scaling looks like the real remaining obstacle. I have not investigated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e7TKYhaJLwpedBBzfRqcK