### PR TITLE
pq_graph: don'\''t dereference end() in compare_scaling (intermittent SIGSEGV at opt_level 6)

### DIFF
--- a/pq_graph/include/scaling_map.hpp
+++ b/pq_graph/include/scaling_map.hpp
@@ -221,6 +221,16 @@ namespace pdaggerq {
                 while ( this_it !=  this_end &&  this_it->second == 0 ) this_it++;
                 while (other_it != other_end && other_it->second == 0 ) other_it++;
 
+                // Re-evaluate after advancing. These flags used to be computed once,
+                // before the loop, so an iterator that reached end() here -- either by
+                // skipping trailing zero occurrences, or because the loop condition below
+                // continues while only ONE map is exhausted -- was not caught by the
+                // checks that follow, and *this_it dereferenced end(). That is undefined
+                // behaviour inside a std::stable_sort comparator, which is how it showed
+                // up: an intermittent SIGSEGV in __unguarded_linear_insert.
+                this_at_end  =  this_it ==  this_end;
+                other_at_end = other_it == other_end;
+
                 if ( this_at_end && !other_at_end) return this_better; // this is cheaper (other has more scalings)
                 if (!this_at_end &&  other_at_end) return this_worse; // this is more expensive (this has more scalings)
                 if (this_at_end  &&  other_at_end) return this_same; // this is the same (equal scalings)


### PR DESCRIPTION
This is, I believe, the intermittent `opt_level = 6` flakiness — not a wrong number, but a **crash**.

### The bug

`scaling_map::compare_scaling` computes its at-end flags once, before the loop:

```cpp
bool this_at_end  = this_it  == this_end;
bool other_at_end = other_it == other_end;
```

and never refreshes them. But the loop advances the iterators in two places:

* the skip-zero loops at the top of each iteration, `while (this_it != this_end && this_it->second == 0) this_it++;`
* the loop condition itself, `while (this_it != this_end || other_it != other_end);` — which deliberately continues while only **one** map is exhausted

Either path can leave an iterator at `end()` while the stale flags say otherwise, so the three at-end checks do not fire and

```cpp
const auto &[this_shape, this_occurrence] = *this_it;
```

dereferences `end()`. The fix re-evaluates the flags after advancing (10 added lines, one file).

### Why it shows up as flaky tests

This is UB *inside a `std::stable_sort` comparator* — `Equation::rearrange` sorts terms by `flop_map()`. So it lands in `std::__unguarded_linear_insert`, the routine that scans backwards trusting the comparator to be a strict weak ordering and runs off the front of the buffer when it is not:

```
#0  Equation::rearrange(...)::<lambda>
#1  std::__unguarded_linear_insert
...
#8  pdaggerq::Equation::rearrange (type="all")
#9  pdaggerq::PQGraph::substitute (only_scalars=true)
#10 pdaggerq::PQGraph::make_scalars
#11 pdaggerq::PQGraph::assemble / optimize
```

Being UB it is sensitive to how the build is optimised — a **RelWithDebInfo** build crashes readily where a **Release** build of the same commit mostly does not — and it is intermittent, since it needs the two maps to differ in a way that exhausts one mid-comparison.

In a suite it is close to undiagnosable: the codegen runs in a subprocess, so the harness reports only a non-zero exit with an **empty stderr**; a **different** eom test fails on each run; and every one of them **passes in isolation**. That is the shape of the failures I was chasing.

### Reproduction

Repeating `pq_graph/tests/eom_ccsd_codegen.py` (opt 6), RelWithDebInfo:

| commit | result |
| --- | --- |
| `d952d5e` (current master) | 3/4 runs SIGSEGV |
| `036a507` (older master) | 2/4 runs SIGSEGV |
| current master + this fix | **0/8 runs SIGSEGV** |

### Verification

* `tests/pq_test.py` + the `pdaggerq` suite: **45 passed**
* `tests/pq_graph_numerical_test.py` (opt 6): **9 passed** — on a build where that same suite failed on each of the two preceding runs

If you have been seeing opt-6 tests that fail in a suite run and pass on their own, this is a good candidate for the cause. Worth building RelWithDebInfo when hunting for the rest: it makes this class of problem far easier to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e7TKYhaJLwpedBBzfRqcK