### PR TITLE
pq_graph: don'\''t re-run a fusion pass once per recursion level

### DIFF
--- a/pq_graph/include/scaling_map.hpp
+++ b/pq_graph/include/scaling_map.hpp
@@ -221,6 +221,16 @@ namespace pdaggerq {
                 while ( this_it !=  this_end &&  this_it->second == 0 ) this_it++;
                 while (other_it != other_end && other_it->second == 0 ) other_it++;
 
+                // Re-evaluate after advancing. These flags used to be computed once,
+                // before the loop, so an iterator that reached end() here -- either by
+                // skipping trailing zero occurrences, or because the loop condition below
+                // continues while only ONE map is exhausted -- was not caught by the
+                // checks that follow, and *this_it dereferenced end(). That is undefined
+                // behaviour inside a std::stable_sort comparator, which is how it showed
+                // up: an intermittent SIGSEGV in __unguarded_linear_insert.
+                this_at_end  =  this_it ==  this_end;
+                other_at_end = other_it == other_end;
+
                 if ( this_at_end && !other_at_end) return this_better; // this is cheaper (other has more scalings)
                 if (!this_at_end &&  other_at_end) return this_worse; // this is more expensive (this has more scalings)
                 if (this_at_end  &&  other_at_end) return this_same; // this is the same (equal scalings)

--- a/pq_graph/src/fusion.cc
+++ b/pq_graph/src/fusion.cc
@@ -774,23 +774,32 @@ size_t PQGraph::merge_intermediates(){
         guard.lock();
     }
 
-    // count terms in pq_graph
-    size_t num_terms = get_num_terms();
+    // Repeat passes until one fuses nothing.
+    //
+    // This used to recurse: the loop called merge_intermediates(), which ran a pass and
+    // then looped on ITS return value, so every nesting level added its own "did anything
+    // change?" pass on top of the one its child had already run. Three productive passes
+    // therefore cost six. A pass is expensive even when it merges nothing -- on the
+    // UCCSD(4) energy it is minutes -- so half the fusion time went on confirming,
+    // repeatedly, that there was nothing left to do.
+    size_t num_fused_total = 0;
+    while (true) {
 
-    LinkMerger link_merger(*this);
-    link_merger.populate();
-    link_merger.prune();
-    link_merger.print();
-    link_merger.merge();
-    link_merger.clear();
+        // count terms in pq_graph
+        size_t num_terms = get_num_terms();
 
-    size_t fused_terms = get_num_terms();
-    fused_terms = num_terms - fused_terms;
-    collect_scaling();
+        LinkMerger link_merger(*this);
+        link_merger.populate();
+        link_merger.prune();
+        link_merger.print();
+        link_merger.merge();
+        link_merger.clear();
 
-    size_t num_fused_total = fused_terms;
-    while (fused_terms > 0) {
-        fused_terms = merge_intermediates(); // recursively merge intermediates until no more terms are fused
+        size_t fused_terms = get_num_terms();
+        fused_terms = num_terms - fused_terms;   // unchanged arithmetic
+        collect_scaling();
+
+        if (fused_terms == 0) break;
         num_fused_total += fused_terms;
     }
 


### PR DESCRIPTION
**Stacked on #134** — it contains that commit, and depends on it (see the end).

### The problem

`merge_intermediates()` runs a populate/prune/merge pass and then loops:

```cpp
size_t num_fused_total = fused_terms;
while (fused_terms > 0) {
    fused_terms = merge_intermediates();   // recurses
    num_fused_total += fused_terms;
}
```

Because the recursive call loops on *its own* return value, every nesting level adds a further "did anything change?" pass on top of the one its child already ran. k productive passes cost about 2k passes instead of k+1.

Tracing pass boundaries on the UCCSD(4) energy (`uccsd_energy(4)`, opt 6):

```
before=742 after=391 diff=351     productive
before=391 after=387 diff=4       productive
before=387 after=386 diff=1       productive
before=386 after=386 diff=0       wasted
before=386 after=386 diff=0       wasted
before=386 after=386 diff=0       wasted
```

Three productive passes, six run. And a pass is expensive *even when it merges nothing*: with `PQ_FUSION_MAX_MERGES=0` — which lets the pass run but merge nothing — that equation still spends minutes in it. So roughly half the fusion phase went on confirming, repeatedly, that there was nothing left to do.

Flattening the recursion into a loop gives the same passes without the redundant confirmations: **4 instead of 6**, with the identical fusion result (742 → 391 → 387 → 386 terms either way).

### On not quoting a speedup

I deliberately give no timing figure. The machine I developed this on varies its clock by more than 5× (400 MHz to 2200 MHz) across a session, which makes any two measurements taken minutes apart incomparable — I got badly misled by exactly that before noticing. The pass count is the honest measure of the work removed; if you want a wall-clock number, please take it on hardware with a fixed governor.

### Dependency on #134

This needs the `compare_scaling` fix. Before it, changing the pass structure altered how often an existing `end()`-dereference was hit, which surfaced as intermittent SIGSEGVs and made *this* change look like the cause. With #134 in place it is clean.

### Verification (on top of #134)

* generated code **byte-identical** to the same tree without this change
* `eom_ccsd` codegen at opt 6: **8/8 runs clean**
* `tests/pq_test.py` + the `pdaggerq` suite: **45 passed**
* `tests/pq_graph_numerical_test.py` (opt 6): **9 passed**

Happy to rebase this once #134 lands, or to drop it if you would rather not touch the fusion driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e7TKYhaJLwpedBBzfRqcK