### PR TITLE
Give Line::subscript_map_ a single out-of-line definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ pybind11_add_module(_pdaggerq
         pdaggerq/pq_helper.cc
 
         pq_graph/include/line.hpp
+        pq_graph/src/line.cc
         pq_graph/include/shape.hpp
         pq_graph/src/vertex.cc
         pq_graph/src/linkage.cc

--- a/pq_graph/include/line.hpp
+++ b/pq_graph/include/line.hpp
@@ -267,7 +267,15 @@ namespace pdaggerq {
         // keyed by LABEL rather than by Line: two lines with the same label are the same
         // index and must share a subscript (spin-blocked equations reuse a label across
         // blocks, and those must not be split apart).
-        static inline thread_local std::unordered_map<std::string, char> subscript_map_{};
+        //
+        // Declared (not defined/inline) here -- defined once in line.cc. `static inline
+        // thread_local` is standard-legal and normally lets the linker merge the per-TU
+        // definitions, but at least one toolchain in the wild (recent AppleClang/ld64) has
+        // been observed emitting a duplicate-symbol error for the compiler-generated
+        // "thread-local initialization routine" for this exact pattern, non-deterministically
+        // across otherwise-identical clean builds. The traditional out-of-line-definition
+        // pattern below sidesteps inline-merging for this symbol entirely.
+        static thread_local std::unordered_map<std::string, char> subscript_map_;
 
         char einsum_char() const {
             auto it = subscript_map_.find(label_);

--- a/pq_graph/src/line.cc
+++ b/pq_graph/src/line.cc
@@ -1,0 +1,30 @@
+//
+// pdaggerq - A code for bringing strings of creation / annihilation operators to normal order.
+// Filename: line.cc
+// Copyright (C) 2020 A. Eugene DePrince III
+//
+// Author: A. Eugene DePrince III <adeprince@fsu.edu>
+// Maintainer: DePrince group
+//
+// This file is part of the pdaggerq package.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#include "../include/line.hpp"
+
+// Single out-of-line definition of Line::subscript_map_ (declared thread_local in
+// line.hpp, not inline -- see the comment there for why).
+namespace pdaggerq {
+    thread_local std::unordered_map<std::string, char> Line::subscript_map_{};
+}


### PR DESCRIPTION
pq_graph/include/line.hpp declared this thread_local map as `static inline thread_local ... subscript_map_{};` -- standard-legal C++17, and normally the linker merges the per-translation-unit definitions transparently. In practice, on at least one toolchain (reported: recent AppleClang/ld64), this has produced

    duplicate symbol 'thread-local initialization routine for
    pdaggerq::Line::subscript_map_' in:
        .../graph_printing.cc.o
        .../printers/einsum_printer.cc.o

non-deterministically -- a clean rebuild sometimes links fine and sometimes doesn't. Passing NO_EXTRAS to pybind11_add_module (to rule out pybind11's automatic LTO) did not make it go away, so this isn't (only) that.

Rather than continue relying on the compiler/linker's inline-merging for this one thread_local symbol, give it the traditional single out-of-line definition: line.hpp now only declares it (`static thread_local ...`, no `inline`, no in-class initializer), and the new pq_graph/src/line.cc supplies the one definition, added to CMakeLists.txt's _pdaggerq sources. This sidesteps inline-merging for this symbol entirely rather than depending on toolchain behavior that has been observed to be unreliable in the wild.
