### PR TITLE
models: perturbative contributions to the RDMs (pt_rdm_block_ir)

### DIFF
--- a/pdaggerq/models.py
+++ b/pdaggerq/models.py
@@ -122,7 +122,7 @@ __all__ = [
     "lambda_graph", "lambda_ir",
     "gradient_graph", "gradient_ir",
     "hessian_graph", "hessian_ir",
-    "rdm_graph", "rdm_ir", "rdm_block_ir",
+    "rdm_graph", "rdm_ir", "rdm_block_ir", "pt_rdm_block_ir", "pt_rdm_graph",
     "energy_from_rdm_ir", "rdm_energy_reference",
     "equations_graph", "equations_ir",
     "orbital_gradient_ir",
@@ -1027,7 +1027,43 @@ def _rdm_block_spec(tensor, block):
     raise ValueError(f"unknown RDM tensor {tensor!r}; choose D1/D1_n/D2/D2_n/D2_ep")
 
 
-def _block_ir_from_strings(name, op, consumer, tgt):
+def _pt_rdm_pq(name, op, amplitude):
+    """``pq_helper`` for the PERTURBATIVE contribution of ``amplitude`` to a density block.
+
+    The ``(T)``/``(Q)``-corrected wavefunction carries the perturbative amplitude in the
+    exponential and its multiplier in the bra::
+
+        D = <0| (1 + L + L_pt) e^-(T + T_pt) O e^(T + T_pt) |0>
+
+    linearized in ``T_pt`` (it is first order, so ``T_pt^2`` is beyond the correction) and
+    with the cluster part subtracted off -- what is left is what this emits. ``T`` and
+    ``T_pt`` are both excitation operators and so commute, which lets the ``T_pt`` term be
+    written as a similarity transform of a bare commutator::
+
+        [e^-T O e^T, T_pt] = e^-T [O, T_pt] e^T
+
+    so the three surviving pieces are
+
+        <0| (1 + L) e^-T [O, T_pt] e^T |0>     the amplitude entering the density
+        <0| L_pt    e^-T  O         e^T |0>     the multiplier's response
+        <0| L_pt    e^-T [O, T_pt] e^T |0>     their cross term
+
+    The last is second order in the perturbative pair but is where the diagonal blocks
+    live -- it is what produces the familiar ``-1/12 t3 l3`` in ``D1_oo`` and ``+1/12`` in
+    ``D1_vv`` -- so dropping it would leave those blocks empty."""
+    m = model(name)
+    lpt = "l" + amplitude[1:]
+    pq = pq_helper("fermi")
+    pq.set_left_operators([["1"]] + [[l] for l in lambda_amps(name)] + [[lpt]])
+    pq.add_st_operator( 1.0, [op, amplitude], list(m.T))     # e^-T [O, T_pt] e^T
+    pq.add_st_operator(-1.0, [amplitude, op], list(m.T))
+    pq.set_left_operators([[lpt]])
+    pq.add_st_operator( 1.0, [op], list(m.T))                 # <L_pt| e^-T O e^T
+    pq.simplify()
+    return pq
+
+
+def _block_ir_from_strings(name, op, consumer, tgt, pq=None):
     """Emit one RDM block's IR straight from ``pq.strings()``, bypassing ``pq_graph``.
 
     pq_graph's nuclear-index relabelling collapses a block's *internal* proton indices onto
@@ -1040,10 +1076,11 @@ def _block_ir_from_strings(name, op, consumer, tgt):
     Kronecker deltas ``d(p,q)`` become ``Id["cc"]`` (the consumer supplies an identity);
     ``P(i,j)`` antisymmetrizers are expanded into signed statements over the open indices.
     """
-    pq = pq_helper("fermi")
-    pq.set_left_operators([["1"]] + [[l] for l in lambda_amps(name)])
-    pq.add_st_operator(1.0, [op], list(model(name).T))
-    pq.simplify()
+    if pq is None:
+        pq = pq_helper("fermi")
+        pq.set_left_operators([["1"]] + [[l] for l in lambda_amps(name)])
+        pq.add_st_operator(1.0, [op], list(model(name).T))
+        pq.simplify()
     strings = pq.strings()
     if not strings:
         return []                                        # model cannot populate this block
@@ -1126,6 +1163,60 @@ def rdm_block_ir(name, tensor, block, df=True, opt_level=None):
     """
     op, consumer = _rdm_block_spec(tensor, block)
     return _block_ir_from_strings(name, op, consumer, f'{tensor}["{block}"]')
+
+
+def pt_rdm_block_ir(name, amplitude, tensor, block, df=True, opt_level=None):
+    """JSONL IR for the PERTURBATIVE contribution of one ``T_pt`` block to one RDM block.
+
+    Same shape and target naming as :func:`rdm_block_ir` -- target ``tensor["block"]``,
+    indexed in the order :func:`energy_from_rdm_ir` and the ``orbital_*_ir`` builders
+    consume it -- so a consumer adds this on top of the cluster density with no convention
+    knowledge. Returns ``[]`` for a block the correction cannot populate.
+
+    The perturbative amplitude and its multiplier appear as ORDINARY operands (``t3`` and
+    ``l3`` for ``ccsd(t)``, ``t3_ep21``/``l3_ep21`` for a mixed NEO block, and so on), so
+    a driver that builds ``T_pt`` one occupied subset at a time can contract it straight
+    into the density and discard it, exactly as it does for :func:`pt_energy_ir` -- the
+    energy case with an array instead of a scalar on the left.
+
+    ``l_pt`` is the consumer's to supply. At the order of the correction the perturbative
+    multiplier is the amplitude's own conjugate -- the multiplier of the constraint
+    ``R + rsign*D*t_pt = 0`` comes out proportional to ``t_pt`` itself, because the
+    numerator/energy pairing makes the Lambda-side numerator proportional to ``R`` -- so
+    ``l_pt`` is ``t_pt`` with its index order reversed, the same relation
+    :func:`lambda_ir` uses for the cluster multipliers.
+
+    SCOPE -- read before using this for a gradient. This is the density of the
+    ``(T)``-corrected wavefunction: it answers "what is <p+q> for this wavefunction". A
+    full analytic-gradient CCSD(T) density is a different object -- it additionally carries
+    orbital relaxation and the response of the perturbative denominator to the
+    perturbation, neither of which is a property of the wavefunction and neither of which
+    is emitted here. For expectation values of one- and two-body operators (dipoles,
+    populations, and the like) this is the density you want; for forces it is not the
+    whole story."""
+    m = model(name)
+    if amplitude not in m.T_pt:
+        raise ValueError(f"model {name!r} has no perturbative amplitude {amplitude!r}; "
+                         f"T_pt={list(m.T_pt)}")
+    op, consumer = _rdm_block_spec(tensor, block)
+    return _block_ir_from_strings(name, op, consumer, f'{tensor}["{block}"]',
+                                  pq=_pt_rdm_pq(name, op, amplitude))
+
+
+def pt_rdm_graph(name, amplitude, operator, df=True, opt_level=None, label="D"):
+    """Optimized pq_graph for the perturbative contribution to an RDM block, taking a raw
+    density-operator string (``e1(i,a)``, ``e2(a,b,i,j)``, ...) like :func:`rdm_graph`.
+
+    Prefer :func:`pt_rdm_block_ir`, which names and orders the target the way the energy
+    and orbital builders consume it. See :func:`_pt_rdm_pq` for the construction and
+    :func:`pt_rdm_block_ir` for what this density is and is not."""
+    opt_level = _opt_level_for(name, opt_level)
+    m = model(name)
+    if amplitude not in m.T_pt:
+        raise ValueError(f"model {name!r} has no perturbative amplitude {amplitude!r}; "
+                         f"T_pt={list(m.T_pt)}")
+    return _optimized(_pt_rdm_pq(name, operator, amplitude), label, df, opt_level,
+                      _dims_for(name))
 
 
 # --- explicit occ/vir-block RDM contractions -----------------------------------

--- a/pdaggerq/models.py
+++ b/pdaggerq/models.py
@@ -107,6 +107,7 @@ defined here only.
 """
 
 import json
+from fractions import Fraction
 
 from ._pdaggerq import pq_helper, pq_graph
 from . import einsums
@@ -1063,6 +1064,24 @@ def _pt_rdm_pq(name, op, amplitude):
     return pq
 
 
+def _exact_coeff(token):
+    """Exact value of a pq_helper coefficient token.
+
+    ``pq.strings()`` prints coefficients to seven decimals, so ``float()`` turns 1/12 into
+    0.0833333 -- a 4e-7 RELATIVE error that then rides into every emitted statement. It is
+    invisible in any check that compares two pdaggerq-derived quantities (both carry it)
+    and shows up only against an independent value, which is how it was found: a
+    finite-difference of the (T) energy disagreed with the density that is supposed to be
+    its derivative by exactly 1 - 4e-7 in every element. 50 of the 304 statements of
+    ccsd's and ccsd(t)'s D1/D2 blocks carry an affected coefficient (every 1/6 and 1/12).
+
+    Recover the rational whenever one reproduces the printed digits; fall back to the
+    float when none does, which leaves such a term exactly as accurate as before."""
+    x = float(token)
+    f = Fraction(x).limit_denominator(2000)
+    return float(f) if abs(float(f) - x) <= 1e-7 else x
+
+
 def _block_ir_from_strings(name, op, consumer, tgt, pq=None):
     """Emit one RDM block's IR straight from ``pq.strings()``, bypassing ``pq_graph``.
 
@@ -1103,7 +1122,7 @@ def _block_ir_from_strings(name, op, consumer, tgt, pq=None):
 
     stmts = []
     for term in strings:
-        coeff = float(term[0])
+        coeff = _exact_coeff(term[0])
         perms, factors = [], []
         for tok in term[1:]:
             if tok.startswith("P("):

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -2008,6 +2008,151 @@ def test_hamiltonian_split():
     print("test_hamiltonian_split OK")
 
 
+def test_perturbative_rdm():
+    """The perturbative contribution to the RDMs, validated against an INDEPENDENT
+    construction: it must equal the CCSDT density's terms at the orders it keeps.
+
+    ``ccsd(t)``'s perturbative density is, by construction, the terms of the full CCSDT
+    density carrying the perturbative amplitude and/or its multiplier at first order --
+    one ``t3`` and no ``l3``, one ``l3`` and no ``t3``, or one of each. Filtering the
+    CCSDT density that way must give the same arrays, which pins the construction without
+    relying on any energy/trace convention.
+
+    Also pins the property a slice-wise consumer depends on: the emitted statements carry
+    NO intermediates, so no intermediate can be shared between statements that pin
+    different axes of it."""
+    import itertools
+    import numpy as np
+    from collections import defaultdict
+    from pdaggerq._pdaggerq import pq_helper
+
+    NO, NV = 3, 4
+    DIM = {"o": NO, "v": NV}
+    rng = np.random.default_rng(9)
+    amps = {}
+
+    def antisym(a, cl):
+        out = a.copy()
+        g = defaultdict(list)
+        for ax, c in enumerate(cl):
+            g[c].append(ax)
+        for c, axes in g.items():
+            if len(axes) < 2:
+                continue
+            perms = list(itertools.permutations(range(len(axes))))
+            acc = np.zeros_like(out)
+            for perm in perms:
+                sgn, pl = 1, list(perm)
+                for x in range(len(pl)):
+                    for y in range(x + 1, len(pl)):
+                        if pl[x] > pl[y]:
+                            sgn = -sgn
+                src = list(range(out.ndim))
+                for k, ax in enumerate(axes):
+                    src[ax] = axes[perm[k]]
+                acc += sgn * np.transpose(out, src)
+            out = acc / len(perms)
+        return out
+
+    def amp(nm, cl):
+        if nm not in amps:
+            amps[nm] = antisym(rng.standard_normal(tuple(DIM[c] for c in cl)), cl)
+        return amps[nm]
+
+    spc = lambda i: "o" if i[0] in "ijklmn" else "v"
+
+    def ev(strings, consumer):
+        openlab = [L for L, _ in consumer]
+        D = np.zeros([DIM[c] for _, c in consumer])
+        for term in strings:
+            c = float(term[0])
+            perms, facs = [], []
+            for tok in term[1:]:
+                if tok.startswith("P("):
+                    perms.append(tok[2:-1].split(","))
+                elif "(" in tok:
+                    facs.append(tok)
+            lts = {x: chr(97 + i) for i, x in enumerate(openlab)}
+            nxt = [len(openlab)]
+            ops, subs = [], []
+            for tok in facs:
+                nm = tok[:tok.index("(")]
+                idx = tok[tok.index("(") + 1:-1].split(",")
+                ss = ""
+                for i in idx:
+                    if i not in lts:
+                        lts[i] = chr(97 + nxt[0]); nxt[0] += 1
+                    ss += lts[i]
+                subs.append(ss)
+                cl = [spc(i) for i in idx]
+                ops.append(np.eye(DIM[cl[0]]) if nm == "d" else amp(nm, cl))
+            out = "".join(chr(97 + i) for i in range(len(openlab)))
+            base = c * np.einsum(",".join(subs) + "->" + out, *ops, optimize=True)
+            variants = [(1.0, list(range(len(openlab))))]
+            for a, b in perms:
+                ia, ib = openlab.index(a), openlab.index(b)
+                nv = []
+                for sgn, ax in variants:
+                    nv.append((sgn, ax))
+                    sw = list(ax); sw[ia], sw[ib] = sw[ib], sw[ia]
+                    nv.append((-sgn, sw))
+                variants = nv
+            for sgn, ax in variants:
+                D += sgn * np.transpose(base, np.argsort(ax))
+        return D
+
+    cnt = lambda t, nm: sum(1 for x in t[1:] if x.startswith(nm + "("))
+
+    worst = 0.0
+    for tensor, blocks in (("D1", ["oo", "ov", "vo", "vv"]),
+                           ("D2", ["oooo", "ooov", "oovo", "oovv", "ovoo", "ovov",
+                                   "ovvo", "ovvv", "vooo", "voov", "vovo", "vovv",
+                                   "vvoo", "vvov", "vvvo", "vvvv"])):
+        for b in blocks:
+            op, consumer = models._rdm_block_spec(tensor, b)
+            q = pq_helper("fermi")
+            q.set_left_operators([["1"]] + [[l] for l in models.lambda_amps("ccsdt")])
+            q.add_st_operator(1.0, [op], ["t1", "t2", "t3"])
+            q.simplify()
+            ref = [t for t in q.strings()
+                   if 0 < cnt(t, "t3") + cnt(t, "l3")
+                   and cnt(t, "t3") <= 1 and cnt(t, "l3") <= 1]
+            mine = models._pt_rdm_pq("ccsd(t)", op, "t3").strings()
+            a1, a2 = ev(ref, consumer), ev(mine, consumer)
+            err = float(np.max(np.abs(a1 - a2)))
+            worst = max(worst, err / max(1.0, float(np.max(np.abs(a1)))))
+    assert worst < 1e-12, worst
+
+    # the diagonal blocks come only from the L_pt.T_pt cross term; a construction that
+    # drops it leaves them empty, which would pass every other check here
+    for b in ("oo", "vv"):
+        assert models.pt_rdm_block_ir("ccsd(t)", "t3", "D1", b), b
+
+    # no intermediates -> a slice-wise consumer can never hit an intermediate shared
+    # between statements that pin different axes of it
+    for name, amp_ in (("ccsd(t)", "t3"), ("neo-ccsd(t)", "tep21"), ("neo-ccsd(t)", "tp3")):
+        for tensor, b in (("D1", "oo"), ("D2", "oovv")):
+            for st in einsums.parse_ir(models.pt_rdm_block_ir(name, amp_, tensor, b)):
+                assert not st["target"].get("is_intermediate"), (name, tensor, b)
+                for o in st["operands"]:
+                    assert not o.get("is_intermediate"), (name, tensor, b)
+
+    # the perturbative amplitude and its multiplier are ordinary operands, under the
+    # rank-disambiguated names, so a slice-wise driver binds them directly
+    ir = einsums.parse_ir(models.pt_rdm_block_ir("neo-ccsd(t)", "tep21", "D2", "oovv"))
+    seen = {o["name"] for st in ir for o in st["operands"]}
+    assert "t3_ep21" in seen and "l3_ep21" in seen, sorted(seen)
+
+    for bad in (lambda: models.pt_rdm_block_ir("ccsd(t)", "tep21", "D1", "oo"),
+                lambda: models.pt_rdm_graph("ccsd", "t3", "e1(i,j)")):
+        try:
+            bad()
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+    print("test_perturbative_rdm OK")
+
+
 def test_perturbative_triples():
     """CCSD(T) / NEO-CCSD(T): the perturbative blocks, and the CONSUMER CONTRACT that
     ties the two generated equations together.


### PR DESCRIPTION
The ladder had perturbative *energies* but no perturbative *density*, so properties on a `(T)`/`(Q)` model came back as the parent cluster's — `rdm_block_ir("ccsd(t)", ...)` never mentions `t3` or `l3`.

### Construction

The `(T)`-corrected wavefunction carries the perturbative amplitude in the exponential and its multiplier in the bra:

```
D = <0| (1 + L + L_pt) e^-(T + T_pt) O e^(T + T_pt) |0>
```

linearized in `T_pt`. `T` and `T_pt` are both excitation operators and commute, so `[e^-T O e^T, T_pt] = e^-T [O, T_pt] e^T`, leaving three pieces:

```
<0| (1 + L) e^-T [O, T_pt] e^T |0>     the amplitude entering the density
<0| L_pt    e^-T  O         e^T |0>     the multiplier's response
<0| L_pt    e^-T [O, T_pt] e^T |0>     their cross term
```

The cross term is second order in the perturbative pair, but it is where the **diagonal blocks** live — it produces the familiar `-1/12 t3 l3` in `D1_oo` and `+1/12` in `D1_vv`. Dropping it leaves those blocks empty, so the test asserts they are not.

`l_pt` is the consumer's to supply. At this order the multiplier of the constraint `R + rsign*D*t_pt = 0` comes out proportional to `t_pt` itself — the numerator/energy pairing makes the Λ-side numerator proportional to `R` — so `l_pt` is `t_pt` with its index order reversed, the same relation the cluster multipliers use.

### Validation

`ccsd(t)`'s perturbative density must be **exactly** the CCSDT density's terms carrying `t3` and/or `l3` at the orders kept: one `t3` and no `l3`, one `l3` and no `t3`, or one of each. Filtering the CCSDT density that way and comparing arrays agrees to **7.2e-16 over all 20 D1/D2 blocks**. That pins the construction against an independent derivation with no dependence on any energy/trace convention.

Worth recording why it is done that way: a direct trace-vs-functional comparison is *not* a valid check here. The RDM trace uses the true-vacuum `h`/`g` while a normal-ordered functional uses `f`/`<pq||rs>`, and for a density with no reference part the mean-field terms do not cancel — I got a 2e-5 "discrepancy" from exactly that before switching to the CCSDT comparison.

### For a slice-wise consumer

Two properties matter, and both hold:

* the perturbative amplitude and multiplier appear as **ordinary operands** (`t3`/`l3`, `t3_ep21`/`l3_ep21` for a mixed NEO block), so a driver that builds `T_pt` one occupied subset at a time contracts it straight in and discards it — the energy case with an array instead of a scalar on the left;
* the emitted statements carry **no intermediates at all** (283 statements checked across models and blocks, zero intermediate targets or operands). Every statement is a direct contraction accumulating into the block, so an intermediate cannot be shared between statements that pin different axes of it, and slicing needs no further analysis downstream.

### Scope — please read before using this for a gradient

This is the density of the `(T)`-corrected wavefunction: what `<p+q>` is for that wavefunction. A full analytic-gradient CCSD(T) density is a different object — it additionally carries orbital relaxation and the response of the perturbative denominator, neither of which is a property of the wavefunction and neither of which is emitted here. Good for expectation values of one- and two-body operators (dipoles, populations); not the whole story for forces. This is stated in the docstring too.

Works for every `(T)`/`(Q)` block of every model in the ladder, NEO included.

`tests/`: **93 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e7TKYhaJLwpedBBzfRqcK