### PR TITLE
Unify electron/boson and electron/nuclear amplitude naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,20 +238,20 @@ boson creation / annihilation operators, $\hat{b}^{\dagger}$ and $\hat{b}$
 b+
 b-
 ```
-cluster operators that include both n-body electron excitations and m-body photon creation ($T_{n,m}$, with $n=0,1,2,3,4$ and $m=0,1,2$...)
+cluster operators that include both n-body electron excitations and m-body photon creation ($T_{n,m}$, with $n=1,2,3,4$ and $m=1,2,...,9$), or pure m-body photon creation with no electron excitation
 ```
-'t0,1'
-'t1,1'
+'tb1'    # T_{0,1}
+'teb11'  # T_{1,1}
 etc.
 ```
-left-hand operators that include both n-body electron de-excitations and m-body photon annihilation ($L_{n,m}$, with $n=0,1,2,3,4$ and $m=0,1,2$...)
+left-hand operators that include both n-body electron de-excitations and m-body photon annihilation ($L_{n,m}$, with $n=1,2,3,4$ and $m=1,2,...,9$), or pure m-body photon annihilation with no electron de-excitation
 ```
-'l2,2'
+'leb22'  # L_{2,2}
 etc.
 ```
-right-hand operators that include both n-body electron excitations and m-body photon creation ($R_{n,m}$, with $n=0,1,2,3,4$ and $m=0,1,2$...)
+right-hand operators that include both n-body electron excitations and m-body photon creation ($R_{n,m}$, with $n=1,2,3,4$ and $m=1,2,...,9$), or pure m-body photon creation with no electron excitation
 ```
-'r1,2'
+'reb12'  # R_{1,2}
 etc.
 ```
 a  one-body fermionic operator times a boson creation operator, $\sum_{pq} d_{pq} \hat{a}^{\dagger}_p \hat{a}_q \hat{b}^{\dagger}$

--- a/examples/eom_qed_ccsd_21.py
+++ b/examples/eom_qed_ccsd_21.py
@@ -57,16 +57,16 @@ def main():
     c_coeffs = [1.0, 1.0]
 
     # T-operators (assumes T1 transformed integrals)
-    T = ['t2', 't0,1', 't1,1', 't2,1']
+    T = ['t2', 'tb1', 'teb11', 'teb21']
     R = [
         #['r0'],
         ['r1'], ['r2'],
-        ['r0,1'], ['r1,1'], ['r2,1'],
+        ['rb1'], ['reb11'], ['reb21'],
     ]
     L = [
         #['l0'],
         ['l1'], ['l2'],
-        ['l0,1'], ['l1,1'], ['l2,1'],
+        ['lb1'], ['leb11'], ['leb21'],
     ]
 
     # Projection operators for different equations

--- a/examples/eom_qed_ccsd_21_1rdm.py
+++ b/examples/eom_qed_ccsd_21_1rdm.py
@@ -49,11 +49,11 @@ def main():
     """
 
     # cluster operators
-    T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
+    T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
 
     # left and right excitation operators
-    L = [['l0'], ['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
-    R = [['r0'], ['r1'], ['r2'], ['r0,1'], ['r1,1'], ['r2,1']]
+    L = [['l0'], ['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
+    R = [['r0'], ['r1'], ['r2'], ['rb1'], ['reb11'], ['reb21']]
 
     rdms = {
         "D_vv": [['e1(a,b)']], # vv

--- a/examples/eom_qed_ccsd_21_2rdm.py
+++ b/examples/eom_qed_ccsd_21_2rdm.py
@@ -49,11 +49,11 @@ def main():
     """
 
     # cluster operators
-    T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
+    T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
 
     # left and right excitation operators
-    L = [['l0'], ['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
-    R = [['r0'], ['r1'], ['r2'], ['r0,1'], ['r1,1'], ['r2,1']]
+    L = [['l0'], ['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
+    R = [['r0'], ['r1'], ['r2'], ['rb1'], ['reb11'], ['reb21']]
 
     rdms = {
         "D_vvvv": [['e2(a,b,c,d)']], # vvvv

--- a/examples/qed_ccsd_21.py
+++ b/examples/qed_ccsd_21.py
@@ -57,7 +57,7 @@ def main():
     c_coeffs = [1.0, 1.0]
 
     # T-operators (assumes T1 transformed integrals)
-    T = ['t2', 't0,1', 't1,1', 't2,1']
+    T = ['t2', 'tb1', 'teb11', 'teb21']
 
     # Projection operators for different equations
     proj = {

--- a/examples/qed_ccsd_21_codegen.py
+++ b/examples/qed_ccsd_21_codegen.py
@@ -84,7 +84,7 @@ def main():
     c_coeffs = [1.0, 1.0]
 
     # T-operators (assumes T1 transformed integrals)
-    T = ['t2', 't0,1', 't1,1', 't2,1']
+    T = ['t2', 'tb1', 'teb11', 'teb21']
 
     # Projection operators for different equations
     proj = {

--- a/examples/qed_ccsd_22.py
+++ b/examples/qed_ccsd_22.py
@@ -57,7 +57,7 @@ def main():
     c_coeffs = [1.0, 1.0]
 
     # T-operators (assumes T1 transformed integrals)
-    T = ['t2', 't0,1', 't1,1', 't2,1', 't0,2', 't1,2', 't2,2']
+    T = ['t2', 'tb1', 'teb11', 'teb21', 'tb2', 'teb12', 'teb22']
 
     # Projection operators for different equations
     proj = {

--- a/examples/qed_ccsd_22_codegen.py
+++ b/examples/qed_ccsd_22_codegen.py
@@ -84,7 +84,7 @@ def main():
     c_coeffs = [1.0, 1.0]
 
     # T-operators (assumes T1 transformed integrals)
-    T = ['t2', 't0,1', 't1,1', 't2,1', 't0,2', 't1,2', 't2,2']
+    T = ['t2', 'tb1', 'teb11', 'teb21', 'tb2', 'teb12', 'teb22']
 
     # Projection operators for different equations
     proj = {

--- a/pdaggerq/numerical/methods/qed_ccsd_21.py
+++ b/pdaggerq/numerical/methods/qed_ccsd_21.py
@@ -19,7 +19,7 @@ class QED_CCSD_21:
         # Create an empty dictionary to hold the pq-generated equations
         local_namespace = {}
        
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
 
         # Generate equations
         cc_energy_func = cc_residual('cc_energy',
@@ -146,8 +146,8 @@ class QED_CCSD_21:
         local_namespace = {}
 
         # Generate lambda equations
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
-        L = [['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
+        L = [['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
 
         cc_pseudoenergy_func = lambda_cc_pseudoenergy('cc_pseudoenergy',
             L,

--- a/pdaggerq/numerical/methods/qed_ccsd_22.py
+++ b/pdaggerq/numerical/methods/qed_ccsd_22.py
@@ -19,7 +19,7 @@ class QED_CCSD_22:
         # Create an empty dictionary to hold the pq-generated equations
         local_namespace = {}
        
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1', 't0,2', 't1,2', 't2,2']
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21', 'tb2', 'teb12', 'teb22']
 
         # Generate equations
         cc_energy_func = cc_residual('cc_energy',

--- a/pdaggerq/numerical/methods/qed_eomccsd_21.py
+++ b/pdaggerq/numerical/methods/qed_eomccsd_21.py
@@ -21,10 +21,10 @@ class QED_EOMCCSD_21:
         local_namespace = {}
 
         # Generate equations
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
 
         # Generate right-hand sigma equations
-        R = [['r0'], ['r1'], ['r2'], ['r0,1'], ['r1,1'], ['r2,1']]
+        R = [['r0'], ['r1'], ['r2'], ['rb1'], ['reb11'], ['reb21']]
 
         right_sigma0_func = eomcc_sigma('sigma0',
             T,
@@ -130,9 +130,9 @@ class QED_EOMCCSD_21:
         # Generate right-hand sigma equations
         local_namespace = {}
 
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
 
-        L = [['l0'], ['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
+        L = [['l0'], ['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
 
         left_sigma0_func = eomcc_sigma('sigma0',
             T,
@@ -239,9 +239,9 @@ class QED_EOMCCSD_21:
         from pdaggerq.numerical.codegen.autogen import eomcc_density_matrix
 
         # Generate transition density matrix equations
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
-        R = [['r0'], ['r1'], ['r2'], ['r0,1'], ['r1,1'], ['r2,1']]
-        L = [['l0'], ['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
+        R = [['r0'], ['r1'], ['r2'], ['rb1'], ['reb11'], ['reb21']]
+        L = [['l0'], ['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
         tdm_func = eomcc_density_matrix('tdm',
             T,
             L,
@@ -265,9 +265,9 @@ class QED_EOMCCSD_21:
         from pdaggerq.numerical.codegen.autogen import eomcc_density_matrix
 
         # Generate transition density matrix equations
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
-        R = [['r0'], ['r1'], ['r2'], ['r0,1'], ['r1,1'], ['r2,1']]
-        L = [['l0'], ['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
+        R = [['r0'], ['r1'], ['r2'], ['rb1'], ['reb11'], ['reb21']]
+        L = [['l0'], ['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
         opdm_func = eomcc_density_matrix('opdm',
             T,
             L,
@@ -291,9 +291,9 @@ class QED_EOMCCSD_21:
         from pdaggerq.numerical.codegen.autogen import eomcc_tpdm
 
         # Generate tpdm equations
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
-        R = [['r0'], ['r1'], ['r2'], ['r0,1'], ['r1,1'], ['r2,1']]
-        L = [['l0'], ['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
+        R = [['r0'], ['r1'], ['r2'], ['rb1'], ['reb11'], ['reb21']]
+        L = [['l0'], ['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
         tpdm_func = eomcc_tpdm('tpdm',
             T,
             L,
@@ -319,9 +319,9 @@ class QED_EOMCCSD_21:
         from pdaggerq.numerical.codegen.autogen import eomcc_phdm
         
         # Generate transition density matrix equations
-        T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
-        R = [['r0'], ['r1'], ['r2'], ['r0,1'], ['r1,1'], ['r2,1']]
-        L = [['l0'], ['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
+        T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
+        R = [['r0'], ['r1'], ['r2'], ['rb1'], ['reb11'], ['reb21']]
+        L = [['l0'], ['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
         phdm_func = eomcc_phdm('phdm',
             T,
             L,

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2224,40 +2224,67 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
             newguy->set_amplitudes('r', n_create, n_annihilate, 0, labels, op_portions);
 
         }else if (op.substr(0, 3) == "lep" || op.substr(0, 3) == "Lep") {
-            // mixed electron-nuclear lambda (de-excitation) amplitude "lep<ne><np>":
-            // ne electron and np nuclear hole-particle pairs. mirror of "tep".
+            // mixed electron-nuclear left-hand amplitude "lep<ne><np>": ne electron
+            // hole-particle pairs (adjusted for IP/EA/DIP/DEA -- lep serves as both
+            // the ground-state lambda amplitude and the left EOM amplitude, exactly
+            // like bare "l") and np nuclear pairs. mirror of "yep".
             int ne = op.at(3) - '0';
             int nn = op.at(4) - '0';
-
+            int n_annihilate = ne;
+            int n_create     = ne;
             std::string npfx = std::string(1, nuclear_prefix);
-            std::vector<std::string> creators, annihilators, labels_l, labels_r, labels;
+            std::vector<std::string> labels;
 
-            for (int id = 0; id < ne; id++) {
-                std::string o = "o" + std::to_string(occ_label_count++);
-                std::string v = "v" + std::to_string(vir_label_count++);
-                creators.push_back(o+"*"); annihilators.push_back(v);
-                labels_l.push_back(o);     labels_r.push_back(v);
+            if ( ne > 0 ) {
+                if ( left_operators_type == "IP" ) n_annihilate--;
+                if ( left_operators_type == "DIP" ) n_annihilate -= 2;
+                if ( left_operators_type == "EA" ) n_create--;
+                if ( left_operators_type == "DEA" ) n_create -= 2;
+
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "o" + std::to_string(occ_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "v" + std::to_string(vir_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
+                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
+
+                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
+                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
+
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
+
+            std::vector<std::string> n_labels_l, n_labels_r;
             for (int id = 0; id < nn; id++) {
                 std::string o = npfx + "o" + std::to_string(occ_label_count++);
                 std::string v = npfx + "v" + std::to_string(vir_label_count++);
-                creators.push_back(o+"*"); annihilators.push_back(v);
-                labels_l.push_back(o);     labels_r.push_back(v);
+                tmp_string.push_back(o+"*");
+                n_labels_l.push_back(o); n_labels_r.push_back(v);
             }
+            for (int id = 0; id < nn; id++) tmp_string.push_back(n_labels_r[id]);
 
-            for (const auto & c : creators)     tmp_string.push_back(c);
-            for (const auto & a : annihilators) tmp_string.push_back(a);
+            for (const auto & l : n_labels_l) labels.push_back(l);
+            for (int id = (int)n_labels_r.size()-1; id >= 0; id--) labels.push_back(n_labels_r[id]);
 
-            for (const auto & l : labels_l) labels.push_back(l);
-            for (int id = (int)labels_r.size()-1; id >= 0; id--) labels.push_back(labels_r[id]);
-
-            double fe = 1.0, fn = 1.0;
-            for (int id = 0; id < ne; id++) fe *= (id+1);
+            double fn = 1.0;
             for (int id = 0; id < nn; id++) fn *= (id+1);
-            factor *= 1.0 / (fe*fe) / (fn*fn);
+            factor *= 1.0 / (fn*fn);
 
-            int n = ne + nn;
-            newguy->set_amplitudes('l', n, n, 0, labels, op_portions);
+            newguy->set_amplitudes('l', n_create+nn, n_annihilate+nn, 0, labels, op_portions);
 
         }else if (op.substr(0, 2) == "lp" || op.substr(0, 2) == "Lp") {
             // nuclear lambda (de-excitation) amplitude "lp<n>": n nuclear hole-particle
@@ -2284,33 +2311,52 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
             newguy->set_amplitudes('l', n, n, 0, labels, op_portions);
 
         }else if (op.substr(0, 3) == "leb" || op.substr(0, 3) == "Leb") {
-            // mixed electron-boson lambda (de-excitation) amplitude
-            // "leb<ne><nb>": ne electron hole-particle pairs and nb boson
-            // annihilation operators. mirror of "teb".
+            // mixed electron-boson left-hand amplitude "leb<ne><nb>": ne electron
+            // hole-particle pairs (adjusted for IP/EA/DIP/DEA -- leb serves as both
+            // the ground-state lambda amplitude and the left EOM amplitude, exactly
+            // like bare "l") and nb boson annihilation operators. mirror of "yeb".
             int ne = op.at(3) - '0';
             int nb = op.at(4) - '0';
+            int n_annihilate = ne;
+            int n_create     = ne;
+            std::vector<std::string> labels;
 
-            std::vector<std::string> creators, annihilators, labels_l, labels_r, labels;
+            if ( ne > 0 ) {
+                if ( left_operators_type == "IP" ) n_annihilate--;
+                if ( left_operators_type == "DIP" ) n_annihilate -= 2;
+                if ( left_operators_type == "EA" ) n_create--;
+                if ( left_operators_type == "DEA" ) n_create -= 2;
 
-            for (int id = 0; id < ne; id++) {
-                std::string o = "o" + std::to_string(occ_label_count++);
-                std::string v = "v" + std::to_string(vir_label_count++);
-                creators.push_back(o+"*"); annihilators.push_back(v);
-                labels_l.push_back(o);     labels_r.push_back(v);
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "o" + std::to_string(occ_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "v" + std::to_string(vir_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
+                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
+
+                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
+                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
+
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
+
             for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(false);
 
-            for (const auto & c : creators)     tmp_string.push_back(c);
-            for (const auto & a : annihilators) tmp_string.push_back(a);
-
-            for (const auto & l : labels_l) labels.push_back(l);
-            for (int id = (int)labels_r.size()-1; id >= 0; id--) labels.push_back(labels_r[id]);
-
-            double fe = 1.0;
-            for (int id = 0; id < ne; id++) fe *= (id+1);
-            factor *= 1.0 / (fe*fe);
-
-            newguy->set_amplitudes('l', ne, ne, nb, labels, op_portions);
+            newguy->set_amplitudes('l', n_create, n_annihilate, nb, labels, op_portions);
 
         }else if (op.substr(0, 2) == "lb" || op.substr(0, 2) == "Lb") {
             // pure boson lambda amplitude "lb<nb>": nb boson annihilation

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -848,10 +848,11 @@ std::pair<bool,std::vector<pq_operator_terms>> pq_helper::process_cluster_amplit
         for (size_t i = 0; i < in.size(); i++) {
             if ( in[i].substr(0,1) == "t" || in[i].substr(0,1) == "T" ) {
                 // electron cluster amplitudes ("t<n>") are split into excitation
-                // ("te") / de-excitation ("td") forms here. nuclear ("tp") and mixed
-                // ("tep") amplitudes are constructed directly and pass through unsplit.
+                // ("te") / de-excitation ("td") forms here. nuclear ("tp"), boson
+                // ("tb"), and mixed ("tep", "teb") amplitudes are constructed
+                // directly and pass through unsplit.
                 if ( in[i].substr(0,2) != "te" && in[i].substr(0,2) != "td" &&
-                     in[i].substr(0,2) != "tp" ) {
+                     in[i].substr(0,2) != "tp" && in[i].substr(0,2) != "tb" ) {
                     found_t = true;
                     break;
                 }else {
@@ -1867,6 +1868,46 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
 
             newguy->set_amplitudes('t', n, n, 0, labels, op_portions);
 
+        }else if (op.substr(0, 3) == "teb" || op.substr(0, 3) == "Teb") {
+            // mixed electron-boson cluster amplitude "teb<ne><nb>": excitation
+            // only. ne electron particle-hole pairs and nb boson creation
+            // operators. mirror of "tep".
+            int ne = op.at(3) - '0';
+            int nb = op.at(4) - '0';
+
+            std::vector<std::string> creators, annihilators, labels_l, labels_r, labels;
+
+            for (int id = 0; id < ne; id++) {
+                std::string v = "v" + std::to_string(vir_label_count++);
+                std::string o = "o" + std::to_string(occ_label_count++);
+                creators.push_back(v+"*"); annihilators.push_back(o);
+                labels_l.push_back(v);     labels_r.push_back(o);
+            }
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(true);
+
+            for (const auto & c : creators)     tmp_string.push_back(c);
+            for (const auto & a : annihilators) tmp_string.push_back(a);
+
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = (int)labels_r.size()-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            // 1/(ne!)^2: electron antisymmetrizer
+            double fe = 1.0;
+            for (int id = 0; id < ne; id++) fe *= (id+1);
+            factor *= 1.0 / (fe*fe);
+
+            newguy->set_amplitudes('t', ne, ne, nb, labels, op_portions);
+
+        }else if (op.substr(0, 2) == "tb" || op.substr(0, 2) == "Tb") {
+            // pure boson cluster amplitude "tb<nb>": nb boson creation operators,
+            // no electrons. mirror of "tp".
+            int nb = std::stoi(op.substr(2));
+            std::vector<std::string> labels;
+
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(true);
+
+            newguy->set_amplitudes('t', 0, 0, nb, labels, op_portions);
+
         }else if (op.substr(0, 1) == "t"){
 
             int n = std::stoi(op.substr(2));
@@ -1947,26 +1988,9 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 }
                 factor *= 1.0 / my_factor / my_factor;
             }
-    
-            int n_ph = 0;
-            if (op.size() > 3 ) {
-                if ( op.substr(3,1) == ",") {
-                    n_ph = std::stoi(op.substr(4));
-                    if ( op.substr(0,2) == "te" ) {
-                        // excitation
-                        for (int ph = 0; ph < n_ph; ph++) {
-                            newguy->is_boson_dagger.push_back(true);
-                        }
-                    }else if ( op.substr(0,2) == "td" ) {
-                        // de-excitation
-                        for (int ph = 0; ph < n_ph; ph++) {
-                            newguy->is_boson_dagger.push_back(false);
-                        }
-                    }
-                }
-            }
-            newguy->set_amplitudes('t', n, n, n_ph, labels, op_portions);
-    
+
+            newguy->set_amplitudes('t', n, n, 0, labels, op_portions);
+
         }else if (op.substr(0, 1) == "w" || op.substr(0, 1) == "W"){ // w0 B*B
     
             if (op.substr(1, 1) == "0" ){
@@ -1991,25 +2015,168 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
     
                 newguy->is_boson_dagger.push_back(false);
     
-        }else if (op.substr(0, 1) == "r" || op.substr(0, 1) == "R"){
-    
-    
-            int n = std::stoi(op.substr(1));
+        }else if (op.substr(0, 3) == "reb" || op.substr(0, 3) == "Reb") {
+            // mixed electron-boson right-hand operator "reb<n><nb>": n electron
+            // particle-hole pairs (adjusted for IP/EA/DIP/DEA) and nb boson
+            // creation operators. mirror of "teb"; r has no de-excitation form.
+            int n  = op.at(3) - '0';
+            int nb = op.at(4) - '0';
             int n_annihilate = n;
             int n_create     = n;
             std::vector<std::string> labels;
-    
-            if ( n == 0 ){
-    
-                // nothing to do
-    
-            }else {
-    
+
+            if ( n > 0 ) {
                 if ( right_operators_type == "IP" ) n_create--;
                 if ( right_operators_type == "DIP" ) n_create -= 2;
                 if ( right_operators_type == "EA" ) n_annihilate--;
                 if ( right_operators_type == "DEA" ) n_annihilate -= 2;
-    
+
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "v" + std::to_string(vir_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "o" + std::to_string(occ_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
+                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
+
+                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
+                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
+
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
+            }
+
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(true);
+
+            newguy->set_amplitudes('r', n_create, n_annihilate, nb, labels, op_portions);
+
+        }else if (op.substr(0, 2) == "rb" || op.substr(0, 2) == "Rb") {
+            // pure boson right-hand operator "rb<nb>": nb boson creation
+            // operators, no electrons. mirror of "tb".
+            int nb = std::stoi(op.substr(2));
+            std::vector<std::string> labels;
+
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(true);
+
+            newguy->set_amplitudes('r', 0, 0, nb, labels, op_portions);
+
+        }else if (op.substr(0, 3) == "rep" || op.substr(0, 3) == "Rep") {
+            // mixed electron-nuclear right-hand operator "rep<n><np>": n electron
+            // particle-hole pairs (adjusted for IP/EA/DIP/DEA) and np nuclear
+            // pairs. mirror of "tep".
+            int n  = op.at(3) - '0';
+            int nn = op.at(4) - '0';
+            int n_annihilate = n;
+            int n_create     = n;
+            std::string npfx = std::string(1, nuclear_prefix);
+            std::vector<std::string> labels;
+
+            if ( n > 0 ) {
+                if ( right_operators_type == "IP" ) n_create--;
+                if ( right_operators_type == "DIP" ) n_create -= 2;
+                if ( right_operators_type == "EA" ) n_annihilate--;
+                if ( right_operators_type == "DEA" ) n_annihilate -= 2;
+
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "v" + std::to_string(vir_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "o" + std::to_string(occ_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
+                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
+
+                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
+                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
+
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
+            }
+
+            std::vector<std::string> n_labels_l, n_labels_r;
+            for (int id = 0; id < nn; id++) {
+                std::string v = npfx + "v" + std::to_string(vir_label_count++);
+                std::string o = npfx + "o" + std::to_string(occ_label_count++);
+                tmp_string.push_back(v+"*");
+                n_labels_l.push_back(v); n_labels_r.push_back(o);
+            }
+            for (int id = 0; id < nn; id++) tmp_string.push_back(n_labels_r[id]);
+
+            for (const auto & l : n_labels_l) labels.push_back(l);
+            for (int id = (int)n_labels_r.size()-1; id >= 0; id--) labels.push_back(n_labels_r[id]);
+
+            double fn = 1.0;
+            for (int id = 0; id < nn; id++) fn *= (id+1);
+            factor *= 1.0 / (fn*fn);
+
+            newguy->set_amplitudes('r', n_create+nn, n_annihilate+nn, 0, labels, op_portions);
+
+        }else if (op.substr(0, 2) == "rp" || op.substr(0, 2) == "Rp") {
+            // pure nuclear right-hand operator "rp<np>": np nuclear
+            // particle-hole pairs, no electrons. mirror of "tp".
+            int n = std::stoi(op.substr(2));
+            std::string npfx = std::string(1, nuclear_prefix);
+            std::vector<std::string> labels_l, labels_r, labels;
+
+            for (int id = 0; id < n; id++) {
+                std::string v = npfx + "v" + std::to_string(vir_label_count++);
+                std::string o = npfx + "o" + std::to_string(occ_label_count++);
+                tmp_string.push_back(v+"*");
+                labels_l.push_back(v); labels_r.push_back(o);
+            }
+            for (int id = 0; id < n; id++) tmp_string.push_back(labels_r[id]);
+
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = n-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            double f = 1.0;
+            for (int id = 0; id < n; id++) f *= (id+1);
+            factor *= 1.0 / f / f;
+
+            newguy->set_amplitudes('r', n, n, 0, labels, op_portions);
+
+        }else if (op.substr(0, 1) == "r" || op.substr(0, 1) == "R"){
+
+
+            int n = std::stoi(op.substr(1));
+            int n_annihilate = n;
+            int n_create     = n;
+            std::vector<std::string> labels;
+
+            if ( n == 0 ){
+
+                // nothing to do
+
+            }else {
+
+                if ( right_operators_type == "IP" ) n_create--;
+                if ( right_operators_type == "DIP" ) n_create -= 2;
+                if ( right_operators_type == "EA" ) n_annihilate--;
+                if ( right_operators_type == "DEA" ) n_annihilate -= 2;
+
                 std::vector<std::string> op_left;
                 std::vector<std::string> op_right;
                 std::vector<std::string> label_left;
@@ -2032,7 +2199,7 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 for (int id = 0; id < n_annihilate; id++) {
                     tmp_string.push_back(op_right[id]);
                 }
-    
+
                 // tn(ab...
                 for (int id = 0; id < n_create; id++) {
                     labels.push_back(label_left[id]);
@@ -2041,7 +2208,7 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 for (int id = n_annihilate-1; id >= 0; id--) {
                     labels.push_back(label_right[id]);
                 }
-    
+
                 // factor = 1/(n!)^2
                 double my_factor_create = 1.0;
                 double my_factor_annihilate = 1.0;
@@ -2053,18 +2220,9 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 }
                 factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
-    
-            int n_ph = 0;
-            if (op.size() > 2 ) {
-                if ( op.substr(2,1) == ",") {
-                    n_ph = std::stoi(op.substr(3));
-                    for (int ph = 0; ph < n_ph; ph++) {
-                        newguy->is_boson_dagger.push_back(true);
-                    }
-                }
-            }
-            newguy->set_amplitudes('r', n_create, n_annihilate, n_ph, labels, op_portions);
-    
+
+            newguy->set_amplitudes('r', n_create, n_annihilate, 0, labels, op_portions);
+
         }else if (op.substr(0, 3) == "lep" || op.substr(0, 3) == "Lep") {
             // mixed electron-nuclear lambda (de-excitation) amplitude "lep<ne><np>":
             // ne electron and np nuclear hole-particle pairs. mirror of "tep".
@@ -2124,6 +2282,45 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
             factor *= 1.0 / f / f;
 
             newguy->set_amplitudes('l', n, n, 0, labels, op_portions);
+
+        }else if (op.substr(0, 3) == "leb" || op.substr(0, 3) == "Leb") {
+            // mixed electron-boson lambda (de-excitation) amplitude
+            // "leb<ne><nb>": ne electron hole-particle pairs and nb boson
+            // annihilation operators. mirror of "teb".
+            int ne = op.at(3) - '0';
+            int nb = op.at(4) - '0';
+
+            std::vector<std::string> creators, annihilators, labels_l, labels_r, labels;
+
+            for (int id = 0; id < ne; id++) {
+                std::string o = "o" + std::to_string(occ_label_count++);
+                std::string v = "v" + std::to_string(vir_label_count++);
+                creators.push_back(o+"*"); annihilators.push_back(v);
+                labels_l.push_back(o);     labels_r.push_back(v);
+            }
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(false);
+
+            for (const auto & c : creators)     tmp_string.push_back(c);
+            for (const auto & a : annihilators) tmp_string.push_back(a);
+
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = (int)labels_r.size()-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            double fe = 1.0;
+            for (int id = 0; id < ne; id++) fe *= (id+1);
+            factor *= 1.0 / (fe*fe);
+
+            newguy->set_amplitudes('l', ne, ne, nb, labels, op_portions);
+
+        }else if (op.substr(0, 2) == "lb" || op.substr(0, 2) == "Lb") {
+            // pure boson lambda amplitude "lb<nb>": nb boson annihilation
+            // operators, no electrons. mirror of "tb".
+            int nb = std::stoi(op.substr(2));
+            std::vector<std::string> labels;
+
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(false);
+
+            newguy->set_amplitudes('l', 0, 0, nb, labels, op_portions);
 
         }else if (op.substr(0, 1) == "l" || op.substr(0, 1) == "L"){
 
@@ -2185,24 +2382,158 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                     my_factor_annihilate *= (id+1);
                 }
                 factor *= 1.0 / my_factor_create / my_factor_annihilate;
-            
+
             }
-    
-            int n_ph = 0;
-            if (op.size() > 2 ) {
-                if ( op.substr(2,1) == ",") {
-                    n_ph = std::stoi(op.substr(3));
-                    for (int ph = 0; ph < n_ph; ph++) {
-                        newguy->is_boson_dagger.push_back(false);
-                    }
+
+            newguy->set_amplitudes('l', n_create, n_annihilate, 0, labels, op_portions);
+
+        }else if (op.substr(0, 3) == "xeb" || op.substr(0, 3) == "Xeb") {
+            // mixed electron-boson right-hand operator "xeb<n><nb>": n electron
+            // particle-hole pairs (adjusted for IP/EA/DIP/DEA) and nb boson
+            // creation operators. mirror of "reb".
+            int n  = op.at(3) - '0';
+            int nb = op.at(4) - '0';
+            int n_annihilate = n;
+            int n_create     = n;
+            std::vector<std::string> labels;
+
+            if ( n > 0 ) {
+                if ( right_operators_type == "IP" ) n_create--;
+                if ( right_operators_type == "DIP" ) n_create -= 2;
+                if ( right_operators_type == "EA" ) n_annihilate--;
+                if ( right_operators_type == "DEA" ) n_annihilate -= 2;
+
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "v" + std::to_string(vir_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
                 }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "o" + std::to_string(occ_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
+                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
+
+                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
+                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
+
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
-            newguy->set_amplitudes('l', n_create, n_annihilate, n_ph, labels, op_portions);
-    
+
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(true);
+
+            newguy->set_amplitudes('x', n_create, n_annihilate, nb, labels, op_portions);
+
+        }else if (op.substr(0, 2) == "xb" || op.substr(0, 2) == "Xb") {
+            // pure boson right-hand operator "xb<nb>": nb boson creation
+            // operators, no electrons. mirror of "rb".
+            int nb = std::stoi(op.substr(2));
+            std::vector<std::string> labels;
+
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(true);
+
+            newguy->set_amplitudes('x', 0, 0, nb, labels, op_portions);
+
+        }else if (op.substr(0, 3) == "xep" || op.substr(0, 3) == "Xep") {
+            // mixed electron-nuclear right-hand operator "xep<n><np>": n electron
+            // particle-hole pairs (adjusted for IP/EA/DIP/DEA) and np nuclear
+            // pairs. mirror of "rep".
+            int n  = op.at(3) - '0';
+            int nn = op.at(4) - '0';
+            int n_annihilate = n;
+            int n_create     = n;
+            std::string npfx = std::string(1, nuclear_prefix);
+            std::vector<std::string> labels;
+
+            if ( n > 0 ) {
+                if ( right_operators_type == "IP" ) n_create--;
+                if ( right_operators_type == "DIP" ) n_create -= 2;
+                if ( right_operators_type == "EA" ) n_annihilate--;
+                if ( right_operators_type == "DEA" ) n_annihilate -= 2;
+
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "v" + std::to_string(vir_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "o" + std::to_string(occ_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
+                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
+
+                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
+                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
+
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
+            }
+
+            std::vector<std::string> n_labels_l, n_labels_r;
+            for (int id = 0; id < nn; id++) {
+                std::string v = npfx + "v" + std::to_string(vir_label_count++);
+                std::string o = npfx + "o" + std::to_string(occ_label_count++);
+                tmp_string.push_back(v+"*");
+                n_labels_l.push_back(v); n_labels_r.push_back(o);
+            }
+            for (int id = 0; id < nn; id++) tmp_string.push_back(n_labels_r[id]);
+
+            for (const auto & l : n_labels_l) labels.push_back(l);
+            for (int id = (int)n_labels_r.size()-1; id >= 0; id--) labels.push_back(n_labels_r[id]);
+
+            double fn = 1.0;
+            for (int id = 0; id < nn; id++) fn *= (id+1);
+            factor *= 1.0 / (fn*fn);
+
+            newguy->set_amplitudes('x', n_create+nn, n_annihilate+nn, 0, labels, op_portions);
+
+        }else if (op.substr(0, 2) == "xp" || op.substr(0, 2) == "Xp") {
+            // pure nuclear right-hand operator "xp<np>": np nuclear
+            // particle-hole pairs, no electrons. mirror of "rp".
+            int n = std::stoi(op.substr(2));
+            std::string npfx = std::string(1, nuclear_prefix);
+            std::vector<std::string> labels_l, labels_r, labels;
+
+            for (int id = 0; id < n; id++) {
+                std::string v = npfx + "v" + std::to_string(vir_label_count++);
+                std::string o = npfx + "o" + std::to_string(occ_label_count++);
+                tmp_string.push_back(v+"*");
+                labels_l.push_back(v); labels_r.push_back(o);
+            }
+            for (int id = 0; id < n; id++) tmp_string.push_back(labels_r[id]);
+
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = n-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            double f = 1.0;
+            for (int id = 0; id < n; id++) f *= (id+1);
+            factor *= 1.0 / f / f;
+
+            newguy->set_amplitudes('x', n, n, 0, labels, op_portions);
+
         }else if (op.substr(0, 1) == "x" || op.substr(0, 1) == "X"){
-   
-            // more right-hand operators 
-    
+
+            // more right-hand operators
+
             int n = std::stoi(op.substr(1));
             int n_annihilate = n;
             int n_create     = n;
@@ -2262,21 +2593,155 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 }
                 factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
-    
-            int n_ph = 0;
-            if (op.size() > 2 ) {
-                if ( op.substr(2,1) == ",") {
-                    n_ph = std::stoi(op.substr(3));
-                    for (int ph = 0; ph < n_ph; ph++) {
-                        newguy->is_boson_dagger.push_back(true);
-                    }
+
+            newguy->set_amplitudes('x', n_create, n_annihilate, 0, labels, op_portions);
+
+        }else if (op.substr(0, 3) == "yeb" || op.substr(0, 3) == "Yeb") {
+            // mixed electron-boson left-hand operator "yeb<n><nb>": n electron
+            // hole-particle pairs (adjusted for IP/EA/DIP/DEA) and nb boson
+            // annihilation operators. mirror of "leb".
+            int n  = op.at(3) - '0';
+            int nb = op.at(4) - '0';
+            int n_annihilate = n;
+            int n_create     = n;
+            std::vector<std::string> labels;
+
+            if ( n > 0 ) {
+                if ( left_operators_type == "IP" ) n_annihilate--;
+                if ( left_operators_type == "DIP" ) n_annihilate -= 2;
+                if ( left_operators_type == "EA" ) n_create--;
+                if ( left_operators_type == "DEA" ) n_create -= 2;
+
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "o" + std::to_string(occ_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
                 }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "v" + std::to_string(vir_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
+                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
+
+                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
+                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
+
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
-            newguy->set_amplitudes('x', n_create, n_annihilate, n_ph, labels, op_portions);
-    
+
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(false);
+
+            newguy->set_amplitudes('y', n_create, n_annihilate, nb, labels, op_portions);
+
+        }else if (op.substr(0, 2) == "yb" || op.substr(0, 2) == "Yb") {
+            // pure boson left-hand operator "yb<nb>": nb boson annihilation
+            // operators, no electrons. mirror of "lb".
+            int nb = std::stoi(op.substr(2));
+            std::vector<std::string> labels;
+
+            for (int id = 0; id < nb; id++) newguy->is_boson_dagger.push_back(false);
+
+            newguy->set_amplitudes('y', 0, 0, nb, labels, op_portions);
+
+        }else if (op.substr(0, 3) == "yep" || op.substr(0, 3) == "Yep") {
+            // mixed electron-nuclear left-hand operator "yep<n><np>": n electron
+            // hole-particle pairs (adjusted for IP/EA/DIP/DEA) and np nuclear
+            // pairs. mirror of "lep".
+            int n  = op.at(3) - '0';
+            int nn = op.at(4) - '0';
+            int n_annihilate = n;
+            int n_create     = n;
+            std::string npfx = std::string(1, nuclear_prefix);
+            std::vector<std::string> labels;
+
+            if ( n > 0 ) {
+                if ( left_operators_type == "IP" ) n_annihilate--;
+                if ( left_operators_type == "DIP" ) n_annihilate -= 2;
+                if ( left_operators_type == "EA" ) n_create--;
+                if ( left_operators_type == "DEA" ) n_create -= 2;
+
+                std::vector<std::string> op_left;
+                std::vector<std::string> op_right;
+                std::vector<std::string> label_left;
+                std::vector<std::string> label_right;
+                for (int id = 0; id < n_create; id++) {
+                    std::string idx1 = "o" + std::to_string(occ_label_count++);
+                    op_left.push_back(idx1+"*");
+                    label_left.push_back(idx1);
+                }
+                for (int id = 0; id < n_annihilate; id++) {
+                    std::string idx2 = "v" + std::to_string(vir_label_count++);
+                    op_right.push_back(idx2);
+                    label_right.push_back(idx2);
+                }
+                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
+                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
+
+                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
+                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
+
+                double my_factor_create = 1.0;
+                double my_factor_annihilate = 1.0;
+                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
+                factor *= 1.0 / my_factor_create / my_factor_annihilate;
+            }
+
+            std::vector<std::string> n_labels_l, n_labels_r;
+            for (int id = 0; id < nn; id++) {
+                std::string o = npfx + "o" + std::to_string(occ_label_count++);
+                std::string v = npfx + "v" + std::to_string(vir_label_count++);
+                tmp_string.push_back(o+"*");
+                n_labels_l.push_back(o); n_labels_r.push_back(v);
+            }
+            for (int id = 0; id < nn; id++) tmp_string.push_back(n_labels_r[id]);
+
+            for (const auto & l : n_labels_l) labels.push_back(l);
+            for (int id = (int)n_labels_r.size()-1; id >= 0; id--) labels.push_back(n_labels_r[id]);
+
+            double fn = 1.0;
+            for (int id = 0; id < nn; id++) fn *= (id+1);
+            factor *= 1.0 / (fn*fn);
+
+            newguy->set_amplitudes('y', n_create+nn, n_annihilate+nn, 0, labels, op_portions);
+
+        }else if (op.substr(0, 2) == "yp" || op.substr(0, 2) == "Yp") {
+            // pure nuclear left-hand operator "yp<np>": np nuclear hole-particle
+            // pairs, no electrons. mirror of "lp".
+            int n = std::stoi(op.substr(2));
+            std::string npfx = std::string(1, nuclear_prefix);
+            std::vector<std::string> labels_l, labels_r, labels;
+
+            for (int id = 0; id < n; id++) {
+                std::string o = npfx + "o" + std::to_string(occ_label_count++);
+                std::string v = npfx + "v" + std::to_string(vir_label_count++);
+                tmp_string.push_back(o+"*");
+                labels_l.push_back(o); labels_r.push_back(v);
+            }
+            for (int id = 0; id < n; id++) tmp_string.push_back(labels_r[id]);
+
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = n-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            double f = 1.0;
+            for (int id = 0; id < n; id++) f *= (id+1);
+            factor *= 1.0 / f / f;
+
+            newguy->set_amplitudes('y', n, n, 0, labels, op_portions);
+
         }else if (op.substr(0, 1) == "y" || op.substr(0, 1) == "Y"){
-    
-            // more left-hand operators 
+
+            // more left-hand operators
 
             int n = std::stoi(op.substr(1));
             int n_annihilate = n;
@@ -2336,20 +2801,11 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                     my_factor_annihilate *= (id+1);
                 }
                 factor *= 1.0 / my_factor_create / my_factor_annihilate;
-            
+
             }
-    
-            int n_ph = 0;
-            if (op.size() > 2 ) {
-                if ( op.substr(2,1) == ",") {
-                    n_ph = std::stoi(op.substr(3));
-                    for (int ph = 0; ph < n_ph; ph++) {
-                        newguy->is_boson_dagger.push_back(false);
-                    }
-                }
-            }
-            newguy->set_amplitudes('y', n_create, n_annihilate, n_ph, labels, op_portions);
-    
+
+            newguy->set_amplitudes('y', n_create, n_annihilate, 0, labels, op_portions);
+
         }else if (op.substr(0, 1) == "e" || op.substr(0, 1) == "E"){
     
     

--- a/pdaggerq/pq_helper.cc
+++ b/pdaggerq/pq_helper.cc
@@ -2075,13 +2075,15 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
         }else if (op.substr(0, 3) == "rep" || op.substr(0, 3) == "Rep") {
             // mixed electron-nuclear right-hand operator "rep<n><np>": n electron
             // particle-hole pairs (adjusted for IP/EA/DIP/DEA) and np nuclear
-            // pairs. mirror of "tep".
+            // pairs. mirror of "tep": creators (electron then nuclear) are all
+            // pushed before annihilators (electron then nuclear) -- the fermion
+            // sign depends on this relative order, so it must match "tep" exactly.
             int n  = op.at(3) - '0';
             int nn = op.at(4) - '0';
             int n_annihilate = n;
             int n_create     = n;
             std::string npfx = std::string(1, nuclear_prefix);
-            std::vector<std::string> labels;
+            std::vector<std::string> creators, annihilators, labels_l, labels_r, labels;
 
             if ( n > 0 ) {
                 if ( right_operators_type == "IP" ) n_create--;
@@ -2089,48 +2091,35 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 if ( right_operators_type == "EA" ) n_annihilate--;
                 if ( right_operators_type == "DEA" ) n_annihilate -= 2;
 
-                std::vector<std::string> op_left;
-                std::vector<std::string> op_right;
-                std::vector<std::string> label_left;
-                std::vector<std::string> label_right;
                 for (int id = 0; id < n_create; id++) {
-                    std::string idx1 = "v" + std::to_string(vir_label_count++);
-                    op_left.push_back(idx1+"*");
-                    label_left.push_back(idx1);
+                    std::string v = "v" + std::to_string(vir_label_count++);
+                    creators.push_back(v+"*");
+                    labels_l.push_back(v);
                 }
                 for (int id = 0; id < n_annihilate; id++) {
-                    std::string idx2 = "o" + std::to_string(occ_label_count++);
-                    op_right.push_back(idx2);
-                    label_right.push_back(idx2);
+                    std::string o = "o" + std::to_string(occ_label_count++);
+                    annihilators.push_back(o);
+                    labels_r.push_back(o);
                 }
-                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
-                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
-
-                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
-                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
-
-                double my_factor_create = 1.0;
-                double my_factor_annihilate = 1.0;
-                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
-                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
-                factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
-
-            std::vector<std::string> n_labels_l, n_labels_r;
             for (int id = 0; id < nn; id++) {
                 std::string v = npfx + "v" + std::to_string(vir_label_count++);
                 std::string o = npfx + "o" + std::to_string(occ_label_count++);
-                tmp_string.push_back(v+"*");
-                n_labels_l.push_back(v); n_labels_r.push_back(o);
+                creators.push_back(v+"*"); annihilators.push_back(o);
+                labels_l.push_back(v);     labels_r.push_back(o);
             }
-            for (int id = 0; id < nn; id++) tmp_string.push_back(n_labels_r[id]);
 
-            for (const auto & l : n_labels_l) labels.push_back(l);
-            for (int id = (int)n_labels_r.size()-1; id >= 0; id--) labels.push_back(n_labels_r[id]);
+            for (const auto & c : creators)     tmp_string.push_back(c);
+            for (const auto & a : annihilators) tmp_string.push_back(a);
 
-            double fn = 1.0;
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = (int)labels_r.size()-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            double my_factor_create = 1.0, my_factor_annihilate = 1.0, fn = 1.0;
+            for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+            for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
             for (int id = 0; id < nn; id++) fn *= (id+1);
-            factor *= 1.0 / (fn*fn);
+            factor *= 1.0 / my_factor_create / my_factor_annihilate / (fn*fn);
 
             newguy->set_amplitudes('r', n_create+nn, n_annihilate+nn, 0, labels, op_portions);
 
@@ -2227,13 +2216,16 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
             // mixed electron-nuclear left-hand amplitude "lep<ne><np>": ne electron
             // hole-particle pairs (adjusted for IP/EA/DIP/DEA -- lep serves as both
             // the ground-state lambda amplitude and the left EOM amplitude, exactly
-            // like bare "l") and np nuclear pairs. mirror of "yep".
+            // like bare "l") and np nuclear pairs. mirror of "tep"/"yep": creators
+            // (electron then nuclear) are all pushed before annihilators (electron
+            // then nuclear) -- the fermion sign depends on this relative order, so
+            // it must match "tep" exactly.
             int ne = op.at(3) - '0';
             int nn = op.at(4) - '0';
             int n_annihilate = ne;
             int n_create     = ne;
             std::string npfx = std::string(1, nuclear_prefix);
-            std::vector<std::string> labels;
+            std::vector<std::string> creators, annihilators, labels_l, labels_r, labels;
 
             if ( ne > 0 ) {
                 if ( left_operators_type == "IP" ) n_annihilate--;
@@ -2241,48 +2233,35 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 if ( left_operators_type == "EA" ) n_create--;
                 if ( left_operators_type == "DEA" ) n_create -= 2;
 
-                std::vector<std::string> op_left;
-                std::vector<std::string> op_right;
-                std::vector<std::string> label_left;
-                std::vector<std::string> label_right;
                 for (int id = 0; id < n_create; id++) {
-                    std::string idx1 = "o" + std::to_string(occ_label_count++);
-                    op_left.push_back(idx1+"*");
-                    label_left.push_back(idx1);
+                    std::string o = "o" + std::to_string(occ_label_count++);
+                    creators.push_back(o+"*");
+                    labels_l.push_back(o);
                 }
                 for (int id = 0; id < n_annihilate; id++) {
-                    std::string idx2 = "v" + std::to_string(vir_label_count++);
-                    op_right.push_back(idx2);
-                    label_right.push_back(idx2);
+                    std::string v = "v" + std::to_string(vir_label_count++);
+                    annihilators.push_back(v);
+                    labels_r.push_back(v);
                 }
-                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
-                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
-
-                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
-                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
-
-                double my_factor_create = 1.0;
-                double my_factor_annihilate = 1.0;
-                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
-                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
-                factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
-
-            std::vector<std::string> n_labels_l, n_labels_r;
             for (int id = 0; id < nn; id++) {
                 std::string o = npfx + "o" + std::to_string(occ_label_count++);
                 std::string v = npfx + "v" + std::to_string(vir_label_count++);
-                tmp_string.push_back(o+"*");
-                n_labels_l.push_back(o); n_labels_r.push_back(v);
+                creators.push_back(o+"*"); annihilators.push_back(v);
+                labels_l.push_back(o);     labels_r.push_back(v);
             }
-            for (int id = 0; id < nn; id++) tmp_string.push_back(n_labels_r[id]);
 
-            for (const auto & l : n_labels_l) labels.push_back(l);
-            for (int id = (int)n_labels_r.size()-1; id >= 0; id--) labels.push_back(n_labels_r[id]);
+            for (const auto & c : creators)     tmp_string.push_back(c);
+            for (const auto & a : annihilators) tmp_string.push_back(a);
 
-            double fn = 1.0;
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = (int)labels_r.size()-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            double my_factor_create = 1.0, my_factor_annihilate = 1.0, fn = 1.0;
+            for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+            for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
             for (int id = 0; id < nn; id++) fn *= (id+1);
-            factor *= 1.0 / (fn*fn);
+            factor *= 1.0 / my_factor_create / my_factor_annihilate / (fn*fn);
 
             newguy->set_amplitudes('l', n_create+nn, n_annihilate+nn, 0, labels, op_portions);
 
@@ -2493,13 +2472,16 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
         }else if (op.substr(0, 3) == "xep" || op.substr(0, 3) == "Xep") {
             // mixed electron-nuclear right-hand operator "xep<n><np>": n electron
             // particle-hole pairs (adjusted for IP/EA/DIP/DEA) and np nuclear
-            // pairs. mirror of "rep".
+            // pairs. mirror of "tep"/"rep": creators (electron then nuclear) are
+            // all pushed before annihilators (electron then nuclear) -- the
+            // fermion sign depends on this relative order, so it must match "tep"
+            // exactly.
             int n  = op.at(3) - '0';
             int nn = op.at(4) - '0';
             int n_annihilate = n;
             int n_create     = n;
             std::string npfx = std::string(1, nuclear_prefix);
-            std::vector<std::string> labels;
+            std::vector<std::string> creators, annihilators, labels_l, labels_r, labels;
 
             if ( n > 0 ) {
                 if ( right_operators_type == "IP" ) n_create--;
@@ -2507,48 +2489,35 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 if ( right_operators_type == "EA" ) n_annihilate--;
                 if ( right_operators_type == "DEA" ) n_annihilate -= 2;
 
-                std::vector<std::string> op_left;
-                std::vector<std::string> op_right;
-                std::vector<std::string> label_left;
-                std::vector<std::string> label_right;
                 for (int id = 0; id < n_create; id++) {
-                    std::string idx1 = "v" + std::to_string(vir_label_count++);
-                    op_left.push_back(idx1+"*");
-                    label_left.push_back(idx1);
+                    std::string v = "v" + std::to_string(vir_label_count++);
+                    creators.push_back(v+"*");
+                    labels_l.push_back(v);
                 }
                 for (int id = 0; id < n_annihilate; id++) {
-                    std::string idx2 = "o" + std::to_string(occ_label_count++);
-                    op_right.push_back(idx2);
-                    label_right.push_back(idx2);
+                    std::string o = "o" + std::to_string(occ_label_count++);
+                    annihilators.push_back(o);
+                    labels_r.push_back(o);
                 }
-                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
-                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
-
-                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
-                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
-
-                double my_factor_create = 1.0;
-                double my_factor_annihilate = 1.0;
-                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
-                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
-                factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
-
-            std::vector<std::string> n_labels_l, n_labels_r;
             for (int id = 0; id < nn; id++) {
                 std::string v = npfx + "v" + std::to_string(vir_label_count++);
                 std::string o = npfx + "o" + std::to_string(occ_label_count++);
-                tmp_string.push_back(v+"*");
-                n_labels_l.push_back(v); n_labels_r.push_back(o);
+                creators.push_back(v+"*"); annihilators.push_back(o);
+                labels_l.push_back(v);     labels_r.push_back(o);
             }
-            for (int id = 0; id < nn; id++) tmp_string.push_back(n_labels_r[id]);
 
-            for (const auto & l : n_labels_l) labels.push_back(l);
-            for (int id = (int)n_labels_r.size()-1; id >= 0; id--) labels.push_back(n_labels_r[id]);
+            for (const auto & c : creators)     tmp_string.push_back(c);
+            for (const auto & a : annihilators) tmp_string.push_back(a);
 
-            double fn = 1.0;
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = (int)labels_r.size()-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            double my_factor_create = 1.0, my_factor_annihilate = 1.0, fn = 1.0;
+            for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+            for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
             for (int id = 0; id < nn; id++) fn *= (id+1);
-            factor *= 1.0 / (fn*fn);
+            factor *= 1.0 / my_factor_create / my_factor_annihilate / (fn*fn);
 
             newguy->set_amplitudes('x', n_create+nn, n_annihilate+nn, 0, labels, op_portions);
 
@@ -2702,13 +2671,16 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
         }else if (op.substr(0, 3) == "yep" || op.substr(0, 3) == "Yep") {
             // mixed electron-nuclear left-hand operator "yep<n><np>": n electron
             // hole-particle pairs (adjusted for IP/EA/DIP/DEA) and np nuclear
-            // pairs. mirror of "lep".
+            // pairs. mirror of "tep"/"lep": creators (electron then nuclear) are
+            // all pushed before annihilators (electron then nuclear) -- the
+            // fermion sign depends on this relative order, so it must match "tep"
+            // exactly.
             int n  = op.at(3) - '0';
             int nn = op.at(4) - '0';
             int n_annihilate = n;
             int n_create     = n;
             std::string npfx = std::string(1, nuclear_prefix);
-            std::vector<std::string> labels;
+            std::vector<std::string> creators, annihilators, labels_l, labels_r, labels;
 
             if ( n > 0 ) {
                 if ( left_operators_type == "IP" ) n_annihilate--;
@@ -2716,48 +2688,35 @@ std::vector<std::shared_ptr<pq_string>> pq_helper::build_new_strings(double fact
                 if ( left_operators_type == "EA" ) n_create--;
                 if ( left_operators_type == "DEA" ) n_create -= 2;
 
-                std::vector<std::string> op_left;
-                std::vector<std::string> op_right;
-                std::vector<std::string> label_left;
-                std::vector<std::string> label_right;
                 for (int id = 0; id < n_create; id++) {
-                    std::string idx1 = "o" + std::to_string(occ_label_count++);
-                    op_left.push_back(idx1+"*");
-                    label_left.push_back(idx1);
+                    std::string o = "o" + std::to_string(occ_label_count++);
+                    creators.push_back(o+"*");
+                    labels_l.push_back(o);
                 }
                 for (int id = 0; id < n_annihilate; id++) {
-                    std::string idx2 = "v" + std::to_string(vir_label_count++);
-                    op_right.push_back(idx2);
-                    label_right.push_back(idx2);
+                    std::string v = "v" + std::to_string(vir_label_count++);
+                    annihilators.push_back(v);
+                    labels_r.push_back(v);
                 }
-                for (int id = 0; id < n_create; id++)     tmp_string.push_back(op_left[id]);
-                for (int id = 0; id < n_annihilate; id++) tmp_string.push_back(op_right[id]);
-
-                for (int id = 0; id < n_create; id++) labels.push_back(label_left[id]);
-                for (int id = n_annihilate-1; id >= 0; id--) labels.push_back(label_right[id]);
-
-                double my_factor_create = 1.0;
-                double my_factor_annihilate = 1.0;
-                for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
-                for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
-                factor *= 1.0 / my_factor_create / my_factor_annihilate;
             }
-
-            std::vector<std::string> n_labels_l, n_labels_r;
             for (int id = 0; id < nn; id++) {
                 std::string o = npfx + "o" + std::to_string(occ_label_count++);
                 std::string v = npfx + "v" + std::to_string(vir_label_count++);
-                tmp_string.push_back(o+"*");
-                n_labels_l.push_back(o); n_labels_r.push_back(v);
+                creators.push_back(o+"*"); annihilators.push_back(v);
+                labels_l.push_back(o);     labels_r.push_back(v);
             }
-            for (int id = 0; id < nn; id++) tmp_string.push_back(n_labels_r[id]);
 
-            for (const auto & l : n_labels_l) labels.push_back(l);
-            for (int id = (int)n_labels_r.size()-1; id >= 0; id--) labels.push_back(n_labels_r[id]);
+            for (const auto & c : creators)     tmp_string.push_back(c);
+            for (const auto & a : annihilators) tmp_string.push_back(a);
 
-            double fn = 1.0;
+            for (const auto & l : labels_l) labels.push_back(l);
+            for (int id = (int)labels_r.size()-1; id >= 0; id--) labels.push_back(labels_r[id]);
+
+            double my_factor_create = 1.0, my_factor_annihilate = 1.0, fn = 1.0;
+            for (int id = 0; id < n_create; id++)     my_factor_create *= (id+1);
+            for (int id = 0; id < n_annihilate; id++) my_factor_annihilate *= (id+1);
             for (int id = 0; id < nn; id++) fn *= (id+1);
-            factor *= 1.0 / (fn*fn);
+            factor *= 1.0 / my_factor_create / my_factor_annihilate / (fn*fn);
 
             newguy->set_amplitudes('y', n_create+nn, n_annihilate+nn, 0, labels, op_portions);
 

--- a/pq_graph/examples/eom_ea_qed_ccsd.py
+++ b/pq_graph/examples/eom_ea_qed_ccsd.py
@@ -76,20 +76,20 @@ def main():
     c_coeffs = [1.0, 1.0]
 
     # T-operators (assumes T1 transformed integrals)
-    T = ['t2', 't0,1', 't1,1', 't2,1']
+    T = ['t2', 'tb1', 'teb11', 'teb21']
 
     # Exciation operators (truncated ground state)
     R = [
         ['r1'], 
         ['r2'],
-        ['r1,1'],
-        ['r2,1'],
+        ['reb11'],
+        ['reb21'],
     ]
     L = [
         ['l1'], 
         ['l2'],
-        ['l1,1'], 
-        ['l2,1'],
+        ['leb11'], 
+        ['leb21'],
     ]
 
     # Projection operators for different equations

--- a/pq_graph/examples/eom_ee_qed_ccsd_21_1rdm.py
+++ b/pq_graph/examples/eom_ee_qed_ccsd_21_1rdm.py
@@ -64,11 +64,11 @@ def main():
     """
 
     # cluster operators
-    T = ['t1', 't2', 't0,1', 't1,1', 't2,1']
+    T = ['t1', 't2', 'tb1', 'teb11', 'teb21']
 
     # left and right excitation operators
-    L = [['l0'], ['l1'], ['l2'], ['l0,1'], ['l1,1'], ['l2,1']]
-    R = [['r0'], ['r1'], ['r2'], ['r0,1'], ['r1,1'], ['r2,1']]
+    L = [['l0'], ['l1'], ['l2'], ['lb1'], ['leb11'], ['leb21']]
+    R = [['r0'], ['r1'], ['r2'], ['rb1'], ['reb11'], ['reb21']]
 
     rdms = {
         "D_vv": [['e1(a,b)']], # vv

--- a/pq_graph/examples/qed_ccsd_21.py
+++ b/pq_graph/examples/qed_ccsd_21.py
@@ -72,7 +72,7 @@ def main():
     c_coeffs = [1.0, 1.0]
 
     # T-operators (assumes T1 transformed integrals)
-    T = ['t2', 't0,1', 't1,1', 't2,1']
+    T = ['t2', 'tb1', 'teb11', 'teb21']
 
     # Projection operators for different equations
     proj = {

--- a/pq_graph/examples/qed_ccsd_22.py
+++ b/pq_graph/examples/qed_ccsd_22.py
@@ -72,7 +72,7 @@ def main():
     c_coeffs = [1.0, 1.0]
 
     # T-operators (assumes T1 transformed integrals)
-    T = ['t2', 't0,1', 't1,1', 't2,1', 't0,2', 't1,2', 't2,2']
+    T = ['t2', 'tb1', 'teb11', 'teb21', 'tb2', 'teb12', 'teb22']
 
     # Projection operators for different equations
     proj = {

--- a/tests/left_operators_type_neo_qed_test.py
+++ b/tests/left_operators_type_neo_qed_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""
+Regression test for lep/leb (mixed electron-nuclear / electron-boson left-hand
+amplitudes) under IP/EA/DIP/DEA left_operators_type.
+
+lep/leb serve two roles: the ground-state lambda amplitude (left_operators_type
+"EE", the default) AND the left EOM amplitude for IP/EA/DIP/DEA variants -- the
+same dual role that bare "l" already has (see the IP/EA/DIP/DEA rank adjustment
+at the top of its branch in pq_helper.cc). lep/leb were originally built as
+plain de-excitation mirrors of tep/teb with no such adjustment, unlike yep/yeb
+(the analogous right-hand-side-of-the-bra-ket amplitudes for the *left* EOM
+operator X/Y pair), which had it correctly from the start.
+
+Because no NEO or QED IP/EA/DIP/DEA EOMCC test existed, this went undetected:
+lep/leb silently ignored left_operators_type and always built the full,
+EE-shaped (symmetric) rank, rather than the reduced/asymmetric rank IP/EA/DIP/DEA
+require.
+
+Two complementary checks are used:
+
+  1. lep/leb must always produce the SAME result as the already-correct
+     yep/yeb, for every left_operators_type, when paired against the same
+     probe. rep/reb never change shape with left_operators_type (R has no
+     excitation/de-excitation split), so pairing a lep/leb bra against a
+     rep/reb ket isolates exactly the IP/EA/DIP/DEA rank adjustment: pre-fix,
+     lep/leb ignored left_operators_type and stayed shape-matched with
+     rep/reb (spuriously nonzero for IP/EA/DIP/DEA); post-fix, they correctly
+     go to the same (empty) result as yep/yeb.
+
+  2. leb, directly probed with an explicit right-hand operator of the rank
+     IP/EA/DIP/DEA actually require, produces the expected nonzero,
+     single-amplitude result -- confirming the adjustment is not just
+     "different from before" but the *correct* reduced rank.
+
+Run: python left_operators_type_neo_qed_test.py
+"""
+import pytest
+import pdaggerq
+
+LEFT_TYPES = ["EE", "IP", "EA", "DIP", "DEA"]
+
+
+def probe(bra_op, left_type, ket_ops):
+    pq = pdaggerq.pq_helper("fermi")
+    pq.set_left_operators_type(left_type)
+    pq.set_left_operators([[bra_op]])
+    pq.add_operator_product(1.0, ket_ops)
+    pq.simplify()
+    return sorted(" ".join(t) for t in pq.strings())
+
+
+def strip_amplitude_letter(strings, letter, replacement):
+    """Normalize a leading amplitude-name letter (e.g. 'l1_1p' -> 'y1_1p') so
+    that two amplitudes differing only by name compare equal."""
+    return sorted(s.replace(f"{letter}1_1p", f"{replacement}1_1p")
+                   .replace(f"{letter}2_1p", f"{replacement}2_1p")
+                   .replace(f"{letter}1_n", f"{replacement}1_n")
+                   .replace(f"{letter}2_ep", f"{replacement}2_ep")
+                  for s in strings)
+
+
+@pytest.mark.parametrize("left_type", LEFT_TYPES)
+def test_leb_matches_yeb_paired_with_reb(left_type):
+    leb = strip_amplitude_letter(probe("leb11", left_type, ["reb11"]), "l", "y")
+    yeb = strip_amplitude_letter(probe("yeb11", left_type, ["reb11"]), "y", "y")
+    assert leb == yeb
+    # EE is the only shape-matched (symmetric) case against reb11
+    if left_type == "EE":
+        assert len(leb) > 0
+    else:
+        assert leb == []
+
+
+@pytest.mark.parametrize("left_type", LEFT_TYPES)
+def test_lep_matches_yep_paired_with_rep(left_type):
+    lep = strip_amplitude_letter(probe("lep11", left_type, ["rep11"]), "l", "y")
+    yep = strip_amplitude_letter(probe("yep11", left_type, ["rep11"]), "y", "y")
+    assert lep == yep
+    if left_type == "EE":
+        assert len(lep) > 0
+    else:
+        assert lep == []
+
+
+def test_leb_ip_reduces_to_single_occupied_index():
+    leb = probe("leb11", "IP", ["a(i)", "B+"])
+    assert leb == ["+1.000 l1_1p(i)"]
+
+
+def test_leb_ea_reduces_to_single_virtual_index():
+    leb = probe("leb11", "EA", ["a*(a)", "B+"])
+    assert leb == ["+1.000 l1_1p(a)"]
+
+
+def test_leb_dip_reduces_to_two_occupied_indices():
+    leb = probe("leb21", "DIP", ["a(i)", "a(j)", "B+"])
+    assert leb == ["+1.000 l2_1p(j,i)"]
+
+
+def test_leb_dea_reduces_to_two_virtual_indices():
+    leb = probe("leb21", "DEA", ["a*(a)", "a*(b)", "B+"])
+    assert leb == ["+1.000 l2_1p(a,b)"]
+
+
+if __name__ == "__main__":
+    print("Please use pytest to run the tests")
+    print("Syntax: python -m pytest left_operators_type_neo_qed_test.py")
+    import sys
+    sys.exit(1)


### PR DESCRIPTION
Replace 't1,1'-style comma syntax for bosons in coupled cluster, lambda, and EOM amplitudes with a fixed-digit naming scheme that mirrors the existing NEO 'tep'/'tp' convention: teb/tb, leb/lb, reb/rb, xeb/xb, yeb/yb. teb/tb are currently excitation-only and typed directly by the user (no implicit unitary-CC de-excitation split, matching tep/tp's current behavior).

Also extends the mixed/pure-nuclear forms to R/X/Y (rep/rp, xep/xp, yep/yp), which previously had no NEO-aware counterpart at all.

This is a pure input-syntax change: the underlying pq_string/amplitude representation and printed output are unaffected, verified by matching existing references. Combined NEO+QED amplitudes remain out of scope for this change.