### PR TITLE
Explicit antisymmetrization

### DIFF
--- a/pdaggerq/numerical/methods/cc3.py
+++ b/pdaggerq/numerical/methods/cc3.py
@@ -58,18 +58,18 @@ class CC3:
 
         # amplitude dictionaries to pass into the solver
         t1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_residual"]
         }
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
         t3 = {
-            'spaces' : 'vvvooo',
-            'spins' : ['aaaaaa', 'aabaab', 'abbabb', 'bbbbbb'],
+            'spaces' : ['vvv','ooo'],
+            'spins' : [['aaa','aaa'], ['aab','aab'], ['abb','abb'], ['bbb','bbb']],
             'residual' : local_namespace["t3_residual"]
         }
         self.T_list = [t1, t2, t3]

--- a/pdaggerq/numerical/methods/ccd.py
+++ b/pdaggerq/numerical/methods/ccd.py
@@ -40,8 +40,8 @@ class CCD:
 
         # amplitude dictionaries to pass into the solver
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
         self.T_list = [t2]
@@ -102,8 +102,8 @@ class CCD:
 
         # lambda amplitude dictionaries to pass into the solver
         l2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["l2_residual"]
         }
 

--- a/pdaggerq/numerical/methods/ccsd.py
+++ b/pdaggerq/numerical/methods/ccsd.py
@@ -49,13 +49,13 @@ class CCSD:
 
         # amplitude dictionaries to pass into the solver
         t1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_residual"]
         }
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
         self.T_list = [t1, t2]
@@ -126,13 +126,13 @@ class CCSD:
 
         # lambda amplitude dictionaries to pass into the solver
         l1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["l1_residual"]
         }
         l2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["l2_residual"]
         }
 

--- a/pdaggerq/numerical/methods/ccsdt.py
+++ b/pdaggerq/numerical/methods/ccsdt.py
@@ -58,18 +58,18 @@ class CCSDT:
 
         # amplitude dictionaries to pass into the solver
         t1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_residual"]
         }
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
         t3 = {
-            'spaces' : 'vvvooo',
-            'spins' : ['aaaaaa', 'aabaab', 'abbabb', 'bbbbbb'],
+            'spaces' : ['vvv','ooo'],
+            'spins' : [['aaa','aaa'], ['aab','aab'], ['abb','abb'], ['bbb','bbb']],
             'residual' : local_namespace["t3_residual"]
         }
         self.T_list = [t1, t2, t3]
@@ -149,21 +149,20 @@ class CCSDT:
         exec(l3_residual_func, globals(), local_namespace)
 
         # lambda amplitude dictionaries to pass into the solver
+        # lambda amplitude dictionaries to pass into the solver
         l1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["l1_residual"]
         }
-
         l2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["l2_residual"]
         }
-
         l3 = {
-            'spaces' : 'vvvooo',
-            'spins' : ['aaaaaa', 'aabaab', 'abbabb', 'bbbbbb'],
+            'spaces' : ['vvv','ooo'],
+            'spins' : [['aaa','aaa'], ['aab','aab'], ['abb','abb'], ['bbb','bbb']],
             'residual' : local_namespace["l3_residual"]
         }
 

--- a/pdaggerq/numerical/methods/qed_ccsd_21.py
+++ b/pdaggerq/numerical/methods/qed_ccsd_21.py
@@ -84,14 +84,14 @@ class QED_CCSD_21:
 
         # amplitude dictionaries to pass into the solver
         t1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_residual"]
         }
 
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
 
@@ -102,15 +102,15 @@ class QED_CCSD_21:
 
         t1_1p = {
             'nph' : 1,
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_1p_residual"]
         }
 
         t2_1p = {
             'nph' : 1,
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_1p_residual"]
         } 
         
@@ -221,14 +221,14 @@ class QED_CCSD_21:
 
         # lambda amplitude dictionaries to pass into the solver
         l1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["l1_residual"]
         }
 
         l2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["l2_residual"]
         }
 
@@ -239,15 +239,15 @@ class QED_CCSD_21:
 
         l1_1p = {
             'nph' : 1,
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["l1_1p_residual"]
         }
 
         l2_1p = {
             'nph' : 1,
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["l2_1p_residual"]
         } 
 

--- a/pdaggerq/numerical/methods/qed_ccsd_22.py
+++ b/pdaggerq/numerical/methods/qed_ccsd_22.py
@@ -113,13 +113,13 @@ class QED_CCSD_22:
 
         # amplitude dictionaries to pass into the solver
         t1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_residual"]
         }
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
         t0_1p = {
@@ -128,14 +128,14 @@ class QED_CCSD_22:
         }
         t1_1p = {
             'nph' : 1,
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_1p_residual"]
         }
         t2_1p = {
             'nph' : 1,
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_1p_residual"]
         } 
         t0_2p = {
@@ -144,14 +144,14 @@ class QED_CCSD_22:
         }
         t1_2p = {
             'nph' : 2,
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_2p_residual"]
         }
         t2_2p = {
             'nph' : 2,
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_2p_residual"]
         } 
         

--- a/pdaggerq/numerical/methods/quccsd.py
+++ b/pdaggerq/numerical/methods/quccsd.py
@@ -52,13 +52,13 @@ class QUCCSD:
 
         # amplitude dictionaries to pass into the solver
         t1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_residual"]
         }
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
         self.T_list = [t1, t2]

--- a/pdaggerq/numerical/methods/uccsd3.py
+++ b/pdaggerq/numerical/methods/uccsd3.py
@@ -51,13 +51,13 @@ class UCCSD3:
 
         # amplitude dictionaries to pass into the solver
         t1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_residual"]
         }
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
         self.T_list = [t1, t2]

--- a/pdaggerq/numerical/methods/uccsd4.py
+++ b/pdaggerq/numerical/methods/uccsd4.py
@@ -51,13 +51,13 @@ class UCCSD4:
 
         # amplitude dictionaries to pass into the solver
         t1 = {
-            'spaces' : 'vo',
-            'spins' : ['aa', 'bb'],
+            'spaces' : ['v', 'o'],
+            'spins' : [['a','a'], ['b','b']],
             'residual' : local_namespace["t1_residual"]
         }
         t2 = {
-            'spaces' : 'vvoo',
-            'spins' : ['aaaa', 'abab', 'bbbb'],
+            'spaces' : ['vv','oo'],
+            'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
             'residual' : local_namespace["t2_residual"]
         }
         self.T_list = [t1, t2]

--- a/pdaggerq/numerical/solvers/cc.py
+++ b/pdaggerq/numerical/solvers/cc.py
@@ -23,6 +23,8 @@ Solvers for CC and lambda CC. Should work for up to quadruple excitations, plus 
 import numpy as np
 from numpy import einsum
 import types
+import math
+import itertools
  
 import copy
  
@@ -544,6 +546,7 @@ class cc:
  
         # Alias the dictionaries based on the target
         amps = self.L if is_lambda else self.T
+        amps_meta = self.L_meta if is_lambda else self.T_meta
         res_funcs = self.L_residual if is_lambda else self.T_residual
  
         for idx in range(max_iter):
@@ -575,6 +578,9 @@ class cc:
             amp_vec, err_vec = self.pack_diis_vectors(amps, residuals)
             new_amp_vec = diis_update.compute_new_vec(amp_vec, err_vec)
             self.unpack_amp_vector(new_amp_vec, amps)
+
+            # explicitly antisymmetrize amplitudes
+            self.antisymmetrize_amplitudes(amps, amps_meta)
  
             # Calculate new energy
             current_energy = self.cc_energy() - self.hf_energy if not is_lambda else self.cc_pseudoenergy()
@@ -697,3 +703,100 @@ class cc:
         ])
  
         return tpdm_aaaa, tpdm_abab, tpdm_bbbb
+
+    def get_parity(self, p):
+        """
+        Computes the parity of a permutation using inversion counting.
+        Returns 1 for even permutations, -1 for odd permutations.
+        """
+        swaps = 0
+        for i in range(len(p)):
+            for j in range(i + 1, len(p)):
+                if p[i] > p[j]:
+                    swaps += 1
+        return 1 if swaps % 2 == 0 else -1
+
+    def antisymmetrize_tensor(self, tensor, raw_spaces, raw_spins):
+        """
+        Antisymmetrizes a dense tensor in-place, projecting it onto the exactly
+        antisymmetric subspace (respecting left/right operator boundaries).
+    
+        Unlike the EOMCC version this is adapted from -- which unpacks a genuinely
+        sparse (redundant-zero) representation, so summing permutations with sign
+        reconstructs the full tensor with no double counting -- every element of
+        `tensor` here is already populated (and only approximately antisymmetric,
+        e.g. from residual/DIIS floating-point noise). Summing all permutations
+        with sign therefore overcounts by prod(k!) over each permutable group of
+        size k, so the result must be normalized by that factor to be a proper
+        projector (idempotent, and a no-op on an already-exact input).
+        """
+        # 1. Identify groups of identical, permutable indices (unchanged from EOMCC)
+        offset = 0
+        groups = []
+    
+        for space_group, spin_group in zip(raw_spaces, raw_spins):
+    
+            partition_groups = {}
+            for i, (sp, spn) in enumerate(zip(space_group, spin_group)):
+                key = (sp, spn)
+                if key not in partition_groups:
+                    partition_groups[key] = []
+                partition_groups[key].append(offset + i)
+    
+            for key, indices in partition_groups.items():
+                if len(indices) > 1:
+                    groups.append(indices)
+    
+            offset += len(space_group)
+    
+        # If there are no groups to permute (e.g. a rank-1 amplitude), we are done
+        if not groups:
+            return
+    
+        # 2. Generate all allowed permutations for each group, and the
+        # normalization (product of each group's size factorial)
+        group_perms = []
+        norm = 1
+        for g in groups:
+            perms = [(p, self.get_parity(p)) for p in itertools.permutations(g)]
+            group_perms.append(perms)
+            norm *= math.factorial(len(g))
+    
+        # 3. Copy the (approximately antisymmetric) input, then accumulate the
+        # properly antisymmetrized result back into the original array
+        dense_tensor = tensor.copy()
+        tensor.fill(0.0)
+    
+        for combined in itertools.product(*group_perms):
+    
+            axes = list(range(tensor.ndim))
+            total_sign = 1
+    
+            for original_group, (permuted_indices, sign) in zip(groups, combined):
+                for orig_idx, perm_idx in zip(original_group, permuted_indices):
+                    axes[orig_idx] = perm_idx
+                total_sign *= sign
+    
+            tensor += total_sign * dense_tensor.transpose(axes)
+    
+        tensor /= norm
+    
+    
+    def antisymmetrize_amplitudes(self, amps, meta_dict):
+        """
+        Antisymmetrize every tensor in an amplitude dictionary (e.g. self.T or
+        self.L) in place.
+        :param amps: amplitude dict, keyed by base_name -> spin_key -> tensor,
+                     as built by initialize_amplitudes
+        :param meta_dict: meta-data dict (e.g. self.T_meta / self.L_meta) giving
+                           the raw_spaces/raw_spins structure for each base_name,
+                           as built by initialize_amplitudes
+        """
+        for base_name, meta in meta_dict.items():
+            raw_spaces = meta['raw_spaces']
+            if not raw_spaces:
+                continue  # scalar / pure-photon amplitude -- nothing to antisymmetrize
+    
+            for raw_spins in meta['raw_spins']:
+                spin_key = "".join(raw_spins) if isinstance(raw_spins, (list, tuple)) else raw_spins
+                self.antisymmetrize_tensor(amps[base_name][spin_key], raw_spaces, raw_spins)

--- a/pdaggerq/numerical/solvers/cc.py
+++ b/pdaggerq/numerical/solvers/cc.py
@@ -195,69 +195,22 @@ class cc:
         self.T = {}
         self.T_residual = {}
         self.D = {}
+
+        # initialize T amplitude dictionaries
+        self.T = {}
+        self.T_residual = {}
+        self.T_meta = {}
+        self.initialize_amplitudes(T_list, self.T, self.T_residual, self.T_meta, function = 'residual')
+
+        # initialize denominator dictionaries
+        self.D = {}
+        self.initialize_denominators(T_list, self.D)
  
-        for myT in T_list:
- 
-            # vo, vvoo, etc.
-            spaces = myT.get('spaces', '')
- 
-            # Amplitude order (e.g., T1 -> 1, T2 -> 2)
-            order = len(spaces) // 2
- 
-            # Number of photons
-            nph = myT.get('nph', 0)
- 
-            # Base key for this rank (e.g., '1', '2', '0_1p' for 1 photon, '1_1p', etc.)
-            base_name = str(order)
-            if nph > 0:
-                base_name += '_' + str(nph) + 'p'
- 
-            # Initialize nested dictionaries for this rank
-            self.T[base_name] = {}
-            self.D[base_name] = {}
- 
-            # Bind residual method to instance
-            self.T_residual[base_name] = types.MethodType(myT['residual'], self)
- 
-            # Fermionic amplitudes (has spins e.g. 'aa', 'abab')
-            if 'spins' in myT and len(spaces) > 0:
-                rank = len(spaces)
- 
-                for spins in myT['spins']:
-                    shape = tuple(self.dims[space + spin] for space, spin in zip(spaces, spins))
- 
-                    # Initialize denominator accumulator for this spin block
-                    denom = np.zeros(shape)
- 
-                    # Accumulate orbital energy differences
-                    for i, (space, spin) in enumerate(zip(spaces, spins)):
-                        sign = 1.0 if space == 'o' else -1.0
-                        eps_1d = self.eps[spin][self.slices[space + spin]]
- 
-                        b_idx = [n] * rank
-                        b_idx[i] = slice(None)
- 
-                        denom += sign * eps_1d[tuple(b_idx)]
- 
-                    # Subtract photon energy if coupled to photons
-                    if nph > 0:
-                        denom -= nph * self.cavity_frequency
- 
-                    # Store tensors in nested dicts
-                    self.T[base_name][spins] = np.zeros(shape)
-                    self.D[base_name][spins] = 1.0 / denom
- 
-            # Pure photon / zero-fermion amplitudes
-            else:
-                if nph > 0:
-                    # 1-element 1D array for scalar photon amplitudes
-                    self.T[base_name][''] = np.zeros((1,))
-                    # Energy shift is strictly -nph * omega
-                    self.D[base_name][''] = np.array([-1.0 / (nph * self.cavity_frequency)])
- 
-        # lambda amplitudes
-        self.L_list = L_list
-        self.initialize_lambda(L_list = L_list, cc_pseudoenergy_func = cc_pseudoenergy_func)
+        # initialize lambda amplitude dictionaries
+        self.L = {}
+        self.L_residual = {}
+        self.L_meta = {}
+        self.initialize_amplitudes(L_list, self.L, self.L_residual, self.L_meta, function = 'residual')
  
         # hartree-fock energy
         self.hf_energy = ( einsum('ii', self.f_aa[oa, oa]) + einsum('ii', self.f_bb[ob, ob])
@@ -269,54 +222,206 @@ class cc:
  
         # cc energy function
         self.cc_energy = types.MethodType(cc_energy_func, self)
+
+    def initialize_denominators(self, amp_list, denom):
+        """
+        Initialize amplitude denominator dictionaries, mirroring initialize_amplitudes'
+        base_name/spaces/spins structure so the two stay in lockstep.
+        :param amp_list: list of amplitude dictionaries containing spaces / spins / nph
+        :param denom: denominator dictionary to populate
+        """
+    
+        dims = {
+            'va': self.nva,
+            'oa': self.noa,
+            'vb': self.nvb,
+            'ob': self.nob
+        }
+    
+        for my_amp in amp_list:
+    
+            raw_spaces = my_amp.get('spaces', [])
+            if raw_spaces and len(raw_spaces) != 2:
+                raise Exception("amp_list spaces should have exactly two elements (left/right)")
+            full_spaces = "".join(raw_spaces)
+    
+            order = max(len(raw_spaces[0]), len(raw_spaces[1])) if raw_spaces else 0
+    
+            nph = my_amp.get('nph', 0)
+    
+            base_name = str(order)
+            if nph > 0:
+                base_name += '_' + str(nph) + 'p'
+    
+            denom[base_name] = {}
+    
+            rank = len(full_spaces)
+    
+            if 'spins' in my_amp and rank > 0:
+                for raw_spins in my_amp['spins']:
+    
+                    if isinstance(raw_spins, (list, tuple)):
+                        full_spins = "".join(raw_spins)
+                    else:
+                        full_spins = raw_spins
+    
+                    shape = tuple(dims[space + spin] for space, spin in zip(full_spaces, full_spins))
+    
+                    d = np.zeros(shape)
+                    for i, (space, spin) in enumerate(zip(full_spaces, full_spins)):
+                        sign = 1.0 if space == 'o' else -1.0
+                        eps_1d = self.eps[spin][self.slices[space + spin]]
+    
+                        b_idx = [None] * rank
+                        b_idx[i] = slice(None)
+    
+                        d += sign * eps_1d[tuple(b_idx)]
+    
+                    if nph > 0:
+                        d -= nph * self.cavity_frequency
+    
+                    denom[base_name][full_spins] = 1.0 / d
+            else:
+                # scalar / pure-photon amplitude: denominator is purely photonic (or, if
+                # nph == 0 too, this amp is a bare scalar with no well-defined denominator --
+                # matches how initialize_amplitudes stores a dummy zeros((1,)) in that case)
+                d = -nph * self.cavity_frequency if nph > 0 else 0.0
+                denom[base_name][''] = 1.0 / d
+
+    def initialize_amplitudes(self, amp_list, amp, amp_residual, amp_meta, function = 'residual'):
+        """
+        Initialize T or lambda amplitude dictionaries
+        :param amp_list: list of amplitude dictionaries containing spaces / spins / residual function
+        :param amp: amplitude dictionary
+        :param amp_residual: residual function dictionary
+        :param amp_meta: meta-data dictionary for left/right space/spin information
+        :param function: the function in the amp_list element that we wish to initialize
+        """
+
+        dims = {
+            'va': self.nva,
+            'oa': self.noa,
+            'vb': self.nvb,
+            'ob': self.nob
+        } 
+        
+        for my_amp in amp_list:
+        
+            # [v,o], [vv,oo], etc.
+            raw_spaces = my_amp.get('spaces', [])
+        
+            if raw_spaces and len(raw_spaces) != 2:
+                raise Exception("amp_list spaces should have exactly two elements (left/right)")
+            full_spaces = "".join(raw_spaces)
+        
+            # Amplitude order (e.g., T1 -> 1, T2 -> 2)
+            if raw_spaces:
+                order = max(len(raw_spaces[0]), len(raw_spaces[1]))
+            else:
+                order = 0
+
+            # Number of photons
+            nph = my_amp.get('nph', 0)
+
+            # Base key for this rank (e.g., '1', '2', '0_1p' for 1 photon, '1_1p', etc.)
+            base_name = str(order)
+            if nph > 0:
+                base_name += '_' + str(nph) + 'p'
+
+            # Initialize nested dictionaries for this rank
+            amp[base_name] = {}
+
+            # Bind residual function to instance
+            amp_residual[base_name] = types.MethodType(my_amp[function], self)
+
+            # If no spins are provided (like for r0 or pure photons), 
+            # we provide a dummy list [[]] so the packer loops exactly once.
+            raw_spins = my_amp.get('spins', [])
+            if not raw_spins:
+                raw_spins = [[]]
+
+            # Store the exact structural boundaries for the solver
+            amp_meta[base_name] = {
+                'raw_spaces': raw_spaces,
+                'raw_spins': raw_spins
+            }
+
+            if 'spins' in my_amp and len(full_spaces) > 0:
+                for raw_spins in my_amp['spins']:
+
+                    if isinstance(raw_spins, (list, tuple)):
+                        full_spins = "".join(raw_spins)
+                    else:
+                        full_spins = raw_spins
+
+                    shape = tuple(dims[space + spin] for space, spin in zip(full_spaces, full_spins))
+                    amp[base_name][full_spins] = np.zeros(shape, dtype=np.float64)
+            else:
+                amp[base_name][''] = np.zeros((1,), dtype=np.float64)
  
     def initialize_lambda(self, L_list = [], cc_pseudoenergy_func = None):
- 
+        """
+        wrapper for initialize_amplitudes for initializing lambda externally
+        """
+
+        self.L = {}
+        self.L_residual = {}
+        self.L_meta = {}
+        self.initialize_amplitudes(L_list, self.L, self.L_residual, self.L_meta, function = 'residual')
+
         # lambda CC pseudoenergy function
         if cc_pseudoenergy_func is not None:
             self.cc_pseudoenergy = types.MethodType(cc_pseudoenergy_func, self)
         else:
             self.cc_pseudoenergy = lambda: 0.0
+
+    #def initialize_lambda(self, L_list = [], cc_pseudoenergy_func = None):
  
-        self.L = {}
-        self.L_residual = {}
-        for myL in L_list:
+    #    # lambda CC pseudoenergy function
+    #    if cc_pseudoenergy_func is not None:
+    #        self.cc_pseudoenergy = types.MethodType(cc_pseudoenergy_func, self)
+    #    else:
+    #        self.cc_pseudoenergy = lambda: 0.0
  
-            # vo, vvoo, etc.
-            spaces = myL.get('spaces', '')
+    #    self.L = {}
+    #    self.L_residual = {}
+    #    for myL in L_list:
  
-            # Amplitude order (e.g., L1 -> 1, L2 -> 2)
-            order = len(spaces) // 2
+    #        # vo, vvoo, etc.
+    #        spaces = myL.get('spaces', '')
  
-            # Number of photons
-            nph = myL.get('nph', 0)
+    #        # Amplitude order (e.g., L1 -> 1, L2 -> 2)
+    #        order = len(spaces) // 2
  
-            # Base key for this rank (e.g., '1', '2', '0_1p' for 1 photon, '1_1p', etc.)
-            base_name = str(order)
-            if nph > 0:
-                base_name += '_' + str(nph) + 'p'
+    #        # Number of photons
+    #        nph = myL.get('nph', 0)
  
-            # Initialize nested dictionaries for this rank
-            self.L[base_name] = {}
+    #        # Base key for this rank (e.g., '1', '2', '0_1p' for 1 photon, '1_1p', etc.)
+    #        base_name = str(order)
+    #        if nph > 0:
+    #            base_name += '_' + str(nph) + 'p'
  
-            # Bind residual method to instance
-            self.L_residual[base_name] = types.MethodType(myL['residual'], self)
+    #        # Initialize nested dictionaries for this rank
+    #        self.L[base_name] = {}
  
-            # Fermionic amplitudes (has spins e.g. 'aa', 'abab')
-            if 'spins' in myL and len(spaces) > 0:
-                rank = len(spaces)
+    #        # Bind residual method to instance
+    #        self.L_residual[base_name] = types.MethodType(myL['residual'], self)
  
-                for spins in myL['spins']:
-                    shape = tuple(self.dims[space + spin] for space, spin in zip(spaces, spins))
+    #        # Fermionic amplitudes (has spins e.g. 'aa', 'abab')
+    #        if 'spins' in myL and len(spaces) > 0:
+    #            rank = len(spaces)
  
-                    # Store tensors in nested dicts
-                    self.L[base_name][spins] = np.zeros(shape)
+    #            for spins in myL['spins']:
+    #                shape = tuple(self.dims[space + spin] for space, spin in zip(spaces, spins))
  
-            # Pure photon / zero-fermion amplitudes
-            else:
-                if nph > 0:
-                    # 1-element 1D array for scalar photon amplitudes
-                    self.L[base_name][''] = np.zeros((1,))
+    #                # Store tensors in nested dicts
+    #                self.L[base_name][spins] = np.zeros(shape)
+ 
+    #        # Pure photon / zero-fermion amplitudes
+    #        else:
+    #            if nph > 0:
+    #                # 1-element 1D array for scalar photon amplitudes
+    #                self.L[base_name][''] = np.zeros((1,))
  
     def t_solver(self):
         """

--- a/tests/pq_numerical_test.py
+++ b/tests/pq_numerical_test.py
@@ -149,13 +149,13 @@ def test_ccsd_codegen_disk():
 
             # amplitude dictionaries to pass into the solver
             t1 = {
-                'spaces' : 'vo',
-                'spins' : ['aa', 'bb'],
+                'spaces' : ['v','o'],
+                'spins' : [['a','a'], ['b','b']],
                 'residual' : local_namespace["t1_residual"].t1_residual
             }
             t2 = {
-                'spaces' : 'vvoo',
-                'spins' : ['aaaa', 'abab', 'bbbb'],
+                'spaces' : ['vv','oo'],
+                'spins' : [['aa','aa'], ['ab','ab'], ['bb','bb']],
                 'residual' : local_namespace["t2_residual"].t2_residual
             }
 


### PR DESCRIPTION
In numerical implementation of CC, explicitly antisymmetrize T or lambda once per iteration. This PR required refactoring the amplitude dictionaries passed into the solver to separately specify spaces / spins in the occupied and virtual sectors. 