### PR TITLE
build: add an install target and place the module where python can import it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,41 @@ project(pdaggerq LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Where the compiled module is placed.
+#
+# setup.py (i.e. `python -m pip install .`) drives this file and passes an
+# explicit -DCMAKE_LIBRARY_OUTPUT_DIRECTORY so the module is written where
+# setuptools collects it for the wheel. A direct `cmake -B build && cmake
+# --build build` passes no such setting, which leaves the module in the build
+# tree where `import pdaggerq` cannot find it. Default it to the in-source
+# package so a plain cmake build is importable without copying anything by
+# hand; the guard leaves the value passed by setup.py untouched.
+if(NOT DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/pdaggerq")
+endif()
+
 # find pybind11 and set variables for finding the correct python version
 set(PYBIND11_PYTHON_VERSION 3)
 set(PYBIND11_FINDPYTHON ON)
 set(Python3_FIND_STRATEGY LOCATION)
+
+# pybind11 locates python inside its own add_subdirectory scope, so the
+# Python_* variables it sets are not visible here. Find the interpreter
+# ourselves to learn where the install target should place the package.
+# setup.py passes the legacy -DPYTHON_EXECUTABLE; honour it so that installing
+# from inside a virtualenv resolves that environment rather than the system.
+if(DEFINED PYTHON_EXECUTABLE AND NOT DEFINED Python_EXECUTABLE)
+    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+endif()
+# Request the same components pybind11 does, so this find is complete and
+# pybind11's own find_package call becomes a no-op; asking for Interpreter
+# alone would satisfy its Python_FOUND check while leaving the Development
+# component -- and hence python_add_library() -- undefined.
+if(CMAKE_VERSION VERSION_LESS 3.18)
+    find_package(Python COMPONENTS Interpreter Development REQUIRED)
+else()
+    find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+endif()
 
 include(FetchContent)
 FetchContent_Declare(
@@ -94,3 +125,29 @@ pybind11_add_module(_pdaggerq
         pq_graph/src/timer.cc
 
 )
+
+# ---------------------------------------------------------------------------
+# install target
+#
+# `pip install .` never invokes `cmake --install` -- setuptools collects the
+# module straight out of the build directory. A direct cmake build has no such
+# helper, so provide the missing target: it installs the compiled module
+# alongside the pure-python sources, which together form the importable
+# package. Defaults to the site-packages of the interpreter found above, so
+# `cmake --install <builddir>` lands in the active environment; override with
+# -DPDAGGERQ_INSTALL_PYTHONDIR=... to stage it somewhere else.
+# ---------------------------------------------------------------------------
+set(PDAGGERQ_INSTALL_PYTHONDIR "${Python_SITEARCH}"
+    CACHE PATH "Directory the pdaggerq package is installed into")
+
+install(TARGETS _pdaggerq
+        LIBRARY DESTINATION "${PDAGGERQ_INSTALL_PYTHONDIR}/pdaggerq")
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/pdaggerq/"
+        DESTINATION "${PDAGGERQ_INSTALL_PYTHONDIR}/pdaggerq"
+        FILES_MATCHING
+        PATTERN "__pycache__" EXCLUDE
+        PATTERN "*.py")
+
+message(STATUS "pdaggerq: module output  -> ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+message(STATUS "pdaggerq: install target -> ${PDAGGERQ_INSTALL_PYTHONDIR}/pdaggerq")

--- a/README.md
+++ b/README.md
@@ -26,6 +26,31 @@ python -m pip install .
 which should compile pdaggerq.  This command will produce a `build` folder that contains
 the compiled c++ shared library. 
 
+### Building with cmake directly
+
+If you are working on the c++ side it is often more convenient to drive cmake
+yourself, which lets you keep several build trees (release, debug, sanitizer)
+side by side:
+
+```
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+The compiled module is written straight into the in-source `pdaggerq` package,
+so `import pdaggerq` works from the top level directory with no further steps.
+To install that build into the active python environment, run
+
+```
+cmake --install build
+```
+
+which places the module and the python sources in the site-packages directory
+of the interpreter cmake found. Pass `-DPDAGGERQ_INSTALL_PYTHONDIR=<dir>` at
+configure time to install somewhere else, and `-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=<dir>`
+to write the compiled module somewhere other than the in-source package. Both
+paths are echoed at configure time.
+
 ## Quickstart
 
 The following is an example that generates the energy expression for CCSD. 


### PR DESCRIPTION
The cmake build has no `install()` rule, so `cmake --install` fails outright:

```
CMake Error: install target not defined
```

And a direct `cmake -B build && cmake --build build` leaves the compiled module in the build tree, where `import pdaggerq` cannot find it.

Only the sanctioned `python -m pip install .` path works today, because `setup.py` passes an explicit `-DCMAKE_LIBRARY_OUTPUT_DIRECTORY` and collects the module itself. Anyone driving cmake directly — which is what you want when keeping release, debug and sanitizer trees side by side — has to copy the `.so` into the package by hand. That copy is easy to forget, and a stale one silently shadows the build rather than failing loudly.

## Changes

**Default `CMAKE_LIBRARY_OUTPUT_DIRECTORY` to the in-source package**, so a plain cmake build is importable with no copying. Guarded on `NOT DEFINED`, which leaves the value `setup.py` passes untouched.

**Find python in the top-level scope.** pybind11 finds it inside its own `add_subdirectory` scope, so the `Python_*` variables are not visible in this file. Worth a note for reviewers: the components requested here have to match pybind11's. Asking for `Interpreter` alone satisfies pybind11's `Python_FOUND` check while leaving the `Development` component — and hence `python_add_library()` — undefined, which breaks configure with `Unknown CMake command "python_add_library"`. Version-guarded, since `Development.Module` needs cmake 3.18 and the floor here is 3.12.

**Add the `install()` rules**, covering the module and the python sources. Destination defaults to the found interpreter's site-packages, so `cmake --install build` lands in the active environment; override with `-DPDAGGERQ_INSTALL_PYTHONDIR=<dir>`. `__pycache__` is excluded. Both paths are echoed at configure time.

README gains a short section on the direct-cmake workflow.

## Verification

| path | result |
| --- | --- |
| `cmake --build` | module lands in `pdaggerq/`, `import pdaggerq` works from the top level |
| `cmake --install` | 49 `.py` + the module, no `__pycache__`, importable from the install dir |
| `DESTDIR=... cmake --install` | stages the same complete tree under the prefix |
| `pip install .` into a clean venv | unchanged — module in site-packages, source tree untouched |

The last row is the one that matters for regressions: the guard has to defer to `setup.py`, or the wheel would come out empty. Confirmed the `.so` is inside the venv's site-packages and that `pq_helper` works when imported from outside the source tree.

`tests/`: 65 passed (`models_test.py` + `pq_test.py`). `*.so` is already gitignored, so the in-source module does not dirty `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e7TKYhaJLwpedBBzfRqcK