### PR TITLE
Fix stale/missing memory management in the loop and blas backends

### DIFF
--- a/pq_graph/include/printers/blas_printer.h
+++ b/pq_graph/include/printers/blas_printer.h
@@ -17,7 +17,7 @@ public:
     bool   include_line_indices() const override { return false; }
     string condition_closer()     const override { return ""; }
 
-    string allocate(const string& name)             const override;
+    string allocate(const string& name, const string& size_expr) const override;
     string deallocate(const string& name)           const override;
     string perm_delete(const string& name)          const override { return deallocate(name); }
     string condition_open(const set<string>& conds) const override { return ""; }

--- a/pq_graph/include/printers/code_printer.h
+++ b/pq_graph/include/printers/code_printer.h
@@ -54,7 +54,11 @@ public:
 
     // ── Statement generators ──────────────────────────────────────────────
 
-    virtual string allocate(const string& name)             const { return ""; }
+    // size_expr is a runtime dimension-product expression (e.g. "nvirt*nvirt*nocc*nocc"),
+    // built by size_expr(lines) below, for backends (loop/blas) whose allocate() needs a
+    // concrete element count; backends that don't raw-allocate (tamm/tiledarray/einsum)
+    // just ignore it.
+    virtual string allocate(const string& name, const string& size_expr) const { return ""; }
     virtual string deallocate(const string& name)           const = 0;
     virtual string perm_delete(const string& name)          const = 0;
     virtual string condition_open(const set<string>& conds) const;    
@@ -93,6 +97,12 @@ public:
 
     // Map index type character to symbolic dimension name (e.g., 'o' → "nocc").
     virtual string dim_name(char type) const { return ""; }
+
+    // Runtime element-count expression for a tensor with these lines, built from dim_name()
+    // per line (e.g. {'v','v','o','o'} -> "nvirt*nvirt*nocc*nocc"); "1" for a scalar (no
+    // lines). Concrete (not virtual): backends only need to override dim_name() to get a
+    // correct allocate() size for free.
+    string size_expr(const line_vector& lines) const;
 
     // ── Intermediate naming ──────────────────────────────────────────────
 

--- a/pq_graph/include/printers/einsum_printer.h
+++ b/pq_graph/include/printers/einsum_printer.h
@@ -17,7 +17,7 @@ public:
     bool   include_line_indices() const override { return false; }
     string condition_closer()     const override { return ""; }
 
-    string allocate(const string& name)    const override { return ""; }
+    string allocate(const string& name, const string& size_expr) const override { return ""; }
     string deallocate(const string& name)  const override;
     string perm_delete(const string& name) const override;
     string condition_open(const set<string>& conds) const override;

--- a/pq_graph/include/printers/loop_printer.h
+++ b/pq_graph/include/printers/loop_printer.h
@@ -17,7 +17,7 @@ public:
     bool   include_line_indices() const override { return false; }
     string condition_closer()     const override { return ""; }
 
-    string allocate(const string& name)             const override;
+    string allocate(const string& name, const string& size_expr) const override;
     string deallocate(const string& name)           const override;
     string perm_delete(const string& name)          const override { return deallocate(name); }
     string condition_open(const set<string>& conds) const override { return ""; }

--- a/pq_graph/include/printers/tamm_printer.h
+++ b/pq_graph/include/printers/tamm_printer.h
@@ -17,7 +17,7 @@ public:
     bool   include_line_indices() const override { return true; }
     string condition_closer()     const override { return "}"; }
 
-    string allocate(const string& name)    const override;
+    string allocate(const string& name, const string& size_expr) const override;
     string deallocate(const string& name)  const override;
     string perm_delete(const string& name) const override { return ""; }
 

--- a/pq_graph/include/vertex.h
+++ b/pq_graph/include/vertex.h
@@ -71,8 +71,14 @@ namespace pdaggerq {
      */
     struct Vertex : public std::enable_shared_from_this<Vertex> {
 
-        string name_{}; // name of the vertex
-        string base_name_{}; // name of vertex without index markup
+        // name_/base_name_ are a display-string cache derived from the active CodePrinter
+        // (Vertex::printer_) at the time update_name()/format_name() was last called. Leaf
+        // vertices are parsed/constructed (and this cache first populated) before a given
+        // print pass' Vertex::set_printer(print_type) call, so the cache must be refreshable
+        // via a const accessor (VertexPtr is shared_ptr<const Vertex> everywhere) -- hence
+        // mutable here rather than requiring callers to hold a non-const handle.
+        mutable string name_{}; // name of the vertex
+        mutable string base_name_{}; // name of vertex without index markup
 
         // uint_fast8_t is sufficient for up to 255 line indices and is more efficient than size_t, which is 64 bits
         // 255 indices is more than enough for any reasonable vertex.
@@ -206,8 +212,8 @@ namespace pdaggerq {
          * @param ovstring string representation of the vertex
          * @param new_blk_string string representation of the blocks in this vertex
          */
-        void format_name();
-        void update_name(const string &base_name = "") {
+        void format_name() const;
+        void update_name(const string &base_name = "") const {
             if (!base_name.empty())
               base_name_ = base_name;
             format_name();

--- a/pq_graph/src/graph_printing.cc
+++ b/pq_graph/src/graph_printing.cc
@@ -101,22 +101,33 @@ namespace pdaggerq {
 
             for (const auto &term: terms) {
                 VertexPtr lhs = term.lhs();
-                if (!lhs->is_linked() && !lhs->is_constant())
+                if (!lhs->is_linked() && !lhs->is_constant()) {
+                    // leaf vertices are constructed/parsed before this print pass' call to
+                    // Vertex::set_printer(print_type) ever runs, so their cached name_ (used
+                    // by both Vertex::str() in term bodies and name() here) is still stamped
+                    // with whichever printer was active at construction time. Linkages don't
+                    // have this problem: Linkage::str() computes intermediate names fresh via
+                    // format_intermediate_name() on every call, with no caching. Refresh the
+                    // leaf vertex's cached name now so declarations and term bodies agree.
+                    lhs->update_name();
                     names.insert(lhs->name());
-                else if (lhs->is_temp())
+                } else if (lhs->is_temp())
                     names.insert(as_link(lhs)->str(true, false));
 
                 for (const auto &op: term.rhs()) {
-                    if (!op->is_linked() && !op->is_constant())
+                    if (!op->is_linked() && !op->is_constant()) {
+                        op->update_name();
                         names.insert(op->name());
-                    else if (op->is_linked()){
+                    } else if (op->is_linked()){
                         if (op->is_temp())
                             names.insert(as_link(op)->str(true, false));
 
                         vertex_vector vertices = as_link(op)->vertices();
                         for (const auto &vertex: vertices)
-                            if (!vertex->is_linked() && !vertex->is_constant())
+                            if (!vertex->is_linked() && !vertex->is_constant()) {
+                                vertex->update_name();
                                 names.insert(vertex->name());
+                            }
                     }
                 }
 
@@ -366,7 +377,7 @@ namespace pdaggerq {
 
                         // We need to allocate the tmp when using c++ or cpp
                         if (Term::deallocate_) {
-                            string allocatename = printer->allocate(temp->str(true, false));
+                            string allocatename = printer->allocate(temp->str(true, false), printer->size_expr(temp->lines()));
                             if (!allocatename.empty()) {
                                 Term allocateterm(tempterm);
                                 allocateterm.print_override_ = allocatename;
@@ -385,7 +396,7 @@ namespace pdaggerq {
 
                     // We need to allocate the tmp when using c++ or cpp
                     if (Term::deallocate_) {
-                        string allocatename = printer->allocate(temp->str(true, false));
+                        string allocatename = printer->allocate(temp->str(true, false), printer->size_expr(temp->lines()));
                         if (!allocatename.empty()) {
                             Term allocateterm(tempterm);
                             allocateterm.print_override_ = allocatename;
@@ -779,6 +790,18 @@ namespace pdaggerq {
                 perm_term.coefficient_ = fabs(coefficient_); // set coefficient to absolute value of coefficient
                 perm_term.ir_perm_json_ = perm_json; // annotate the group's definition (IR only)
 
+                // for raw-array backends (loop/blas), this intermediate is real allocated
+                // memory, not a language-level tensor object -- allocate it here, paired
+                // with the perm_delete()/deallocate() call below that frees it once this
+                // permutation group's accumulation is done.
+                if (Term::deallocate_) {
+                    string allocname = Vertex::printer_->allocate(perm_vertex->name(), Vertex::printer_->size_expr(perm_vertex->lines()));
+                    if (!allocname.empty()) {
+                        output += allocname;
+                        output += "\n";
+                    }
+                }
+
                 // add string to output
                 output += perm_term.str();
                 output += "\n";
@@ -810,7 +833,11 @@ namespace pdaggerq {
             // if an intermediate vertex was created, delete it
             if (!perm_as_rhs && Term::deallocate_) {
                 string del = Vertex::printer_->perm_delete(perm_vertex->name());
-                if (!del.empty()) output += del;
+                // the pop_back() below unconditionally strips output's last character,
+                // assuming it is the trailing '\n' left by the permuted_term loop above --
+                // append del's own trailing '\n' too, or that pop_back() eats the last
+                // character of del (e.g. the ';' of "free(x); x = NULL;") instead.
+                if (!del.empty()) { output += del; output += '\n'; }
             }
 
             if (!perm_terms.empty())
@@ -846,9 +873,17 @@ namespace pdaggerq {
         if (needs_binarization) {
 
             // copy of current term to modify
-            Term binarized_term = clone(); 
-            bool made_any_change = false;            
+            Term binarized_term = clone();
+            bool made_any_change = false;
             int count = 1;
+
+            // raw-array backends (loop/blas) need each binarization temp actually calloc'd
+            // before use and freed once the fully-binarized term has been rendered (they all
+            // stay live until then -- a later make_interm call can reference an earlier one's
+            // result via binarized_term.rhs_). Backends that don't raw-allocate (tamm/
+            // tiledarray/einsum) get empty strings from allocate()/deallocate() and this is a
+            // no-op for them.
+            vector<MutableVertexPtr> created_temps;
 
             // helper to create intermediate vertex/term and update binarized_term
             auto make_interm = [&](const std::vector<VertexPtr> &verts, size_t erase_pos, size_t erase_count, size_t insert_pos) {
@@ -861,6 +896,7 @@ namespace pdaggerq {
                 interm_vertex->vertex_type_ = (char)count + '0';
                 interm_vertex->sort();
                 interm_vertex->update_name();
+                created_temps.push_back(interm_vertex);
 
                 Term interm_term = binarized_term;
                 interm_term.reset_perm();
@@ -873,6 +909,12 @@ namespace pdaggerq {
 
                 interm_term.compute_scaling(true);
                 interm_term.expand_rhs();
+
+                string allocname = Vertex::printer_->allocate(interm_vertex->name(), Vertex::printer_->size_expr(interm_vertex->lines()));
+                if (!allocname.empty()) {
+                    output += allocname;
+                    output += "\n";
+                }
 
                 output += interm_term.str();
                 output += "\n";
@@ -942,6 +984,20 @@ namespace pdaggerq {
             // now print the final binarized term if a change was made
             if (made_any_change) {
                 output += binarized_term.str();
+                output += "\n";
+
+                // free every binarization temp created above -- all of them are dead once
+                // this fully-binarized term has been rendered
+                for (const auto &temp : created_temps) {
+                    string delname = Vertex::printer_->deallocate(temp->name());
+                    if (!delname.empty()) {
+                        output += delname;
+                        output += "\n";
+                    }
+                }
+                if (output.back() == '\n')
+                    output.pop_back(); // remove trailing newline for consistency with other returns
+
                 return output;
             } // else we continue to print the original term
         }

--- a/pq_graph/src/printers/blas_printer.cc
+++ b/pq_graph/src/printers/blas_printer.cc
@@ -62,8 +62,8 @@ string BLASPrinter::format_intermediate_name(const Linkage* link, bool) const {
     return name;
 }
 
-string BLASPrinter::allocate(const string& name) const {
-    return name + " = (double*)calloc(" + name + "_size, sizeof(double));";
+string BLASPrinter::allocate(const string& name, const string& size_expr) const {
+    return name + " = (double*)calloc(" + size_expr + ", sizeof(double));";
 }
 
 string BLASPrinter::deallocate(const string& name) const {

--- a/pq_graph/src/printers/code_printer.cc
+++ b/pq_graph/src/printers/code_printer.cc
@@ -177,6 +177,18 @@ string CodePrinter::format_term(const Term& t) const {
     return output;
 }
 
+string CodePrinter::size_expr(const line_vector& lines) const {
+    if (lines.empty()) return "1";
+    string expr;
+    for (const auto& line : lines) {
+        string dn = dim_name(line.type());
+        if (dn.empty()) continue; // backend doesn't define dimension names (no raw allocation)
+        if (!expr.empty()) expr += "*";
+        expr += dn;
+    }
+    return expr.empty() ? "1" : expr;
+}
+
 string CodePrinter::format_declarations(const set<string>& names) const {
     string out;
     for (const auto& name : names)

--- a/pq_graph/src/printers/loop_printer.cc
+++ b/pq_graph/src/printers/loop_printer.cc
@@ -62,8 +62,8 @@ string LoopPrinter::format_intermediate_name(const Linkage* link, bool) const {
     return name;
 }
 
-string LoopPrinter::allocate(const string& name) const {
-    return name + " = (double*)calloc(" + name + "_size, sizeof(double));";
+string LoopPrinter::allocate(const string& name, const string& size_expr) const {
+    return name + " = (double*)calloc(" + size_expr + ", sizeof(double));";
 }
 
 string LoopPrinter::deallocate(const string& name) const {

--- a/pq_graph/src/printers/tamm_printer.cc
+++ b/pq_graph/src/printers/tamm_printer.cc
@@ -10,7 +10,7 @@ namespace pdaggerq {
 
 // ── TammPrinter implementations ───────────────────────────────────────────────
 
-string TammPrinter::allocate(const string& name) const {
+string TammPrinter::allocate(const string& name, const string& size_expr) const {
     return ".allocate(" + name + ")";
 }
 

--- a/pq_graph/src/vertex_printing.cc
+++ b/pq_graph/src/vertex_printing.cc
@@ -48,7 +48,7 @@ using std::ostream, std::string, std::vector, std::map, std::unordered_map, std:
 
 namespace pdaggerq {
 
-    void Vertex::format_name() {
+    void Vertex::format_name() const {
         name_ = printer_->format_name(this);
     }
 


### PR DESCRIPTION
Two related bugs in the raw-array ("loop"/"blas") CodePrinter backends:

1. Leaf-vertex display names were stale after switching printers. Vertex::str() returns a cached name_ field that is only refreshed by an explicit update_name()/format_name() call. Leaf tensors (parsed at graph-construction time) get that cache populated under whichever printer was active then -- the process-wide default (TiledArrayPrinter) -- and PQGraph::str(print_type) never invalidated it after calling Vertex::set_printer(print_type). Intermediates created during optimize()/assemble() happened to get a correct cache because they're built after the printer switch, which is why this only affected leaf tensors, and only for backends (loop/blas) whose format_name() differs from the default map-subscript convention. Fixed by refreshing each leaf vertex's name at the three collection sites in PQGraph::str()/graph_printing.cc.

2. Permutation-group and multi-operand-term intermediates were used and freed but never allocated. LoopPrinter/BLASPrinter's allocate() already returned a `calloc(..._size, ...)` string, but nothing ever computed or declared `..._size`, and the two places that create these intermediates (Term::str()'s permutation-group handling, and the shared make_interm() binarization helper used whenever a term has 3+ operands -- which is also what backs the "Scalars" section, e.g. an energy expression) never called allocate() at all, only (sometimes) deallocate(). Fixed by adding CodePrinter::size_expr(lines), a concrete helper that builds a runtime dimension-product expression (e.g. "nvirt*nvirt*nocc*nocc") from a vertex's line types via the existing dim_name() hook, changing allocate()'s signature to take it, and wiring allocate()/deallocate() calls into both previously-unhandled call sites. Also fixes a one-off trailing-semicolon bug in the permutation deallocate path that the missing allocation had been masking.